### PR TITLE
[Miter][US-011]：Support Miter to AIGER/BTOR2【add leading_zero cases】

### DIFF
--- a/test/integration_tests/cases/leading_zero_casex_run_bitwuzla_with_btor2/LZC_CASEX.mlir
+++ b/test/integration_tests/cases/leading_zero_casex_run_bitwuzla_with_btor2/LZC_CASEX.mlir
@@ -1,0 +1,53 @@
+module {
+  hw.module @lzc7_casex(in %mant_in : i7, in %is_zero_in : i1, in %is_infinity_in : i1, in %is_nan_in : i1, in %is_special_in : i1, in %is_inexact_in : i1, out is_zero_out : i1, out is_infinity_out : i1, out is_nan_out : i1, out is_inexact_out : i1, out is_special_out : i1, out lzc : i3) {
+    %true = hw.constant true
+    %c2_i7 = hw.constant 2 : i7
+    %c-2_i7 = hw.constant -2 : i7
+    %c4_i7 = hw.constant 4 : i7
+    %c-4_i7 = hw.constant -4 : i7
+    %c8_i7 = hw.constant 8 : i7
+    %c-8_i7 = hw.constant -8 : i7
+    %c16_i7 = hw.constant 16 : i7
+    %c-16_i7 = hw.constant -16 : i7
+    %c32_i7 = hw.constant 32 : i7
+    %c-32_i7 = hw.constant -32 : i7
+    %c-64_i7 = hw.constant -64 : i7
+    %c-2_i3 = hw.constant -2 : i3
+    %c-3_i3 = hw.constant -3 : i3
+    %c-4_i3 = hw.constant -4 : i3
+    %c3_i3 = hw.constant 3 : i3
+    %c2_i3 = hw.constant 2 : i3
+    %c1_i3 = hw.constant 1 : i3
+    %c0_i3 = hw.constant 0 : i3
+    %0 = comb.and %mant_in, %c-64_i7 : i7
+    %1 = comb.icmp eq %0, %c-64_i7 : i7
+    %2 = comb.and %mant_in, %c-32_i7 : i7
+    %3 = comb.icmp eq %2, %c32_i7 : i7
+    %4 = comb.and %mant_in, %c-16_i7 : i7
+    %5 = comb.icmp eq %4, %c16_i7 : i7
+    %6 = comb.and %mant_in, %c-8_i7 : i7
+    %7 = comb.icmp eq %6, %c8_i7 : i7
+    %8 = comb.and %mant_in, %c-4_i7 : i7
+    %9 = comb.icmp eq %8, %c4_i7 : i7
+    %10 = comb.and %mant_in, %c-2_i7 : i7
+    %11 = comb.icmp eq %10, %c2_i7 : i7
+    %12 = comb.mux %11, %c-3_i3, %c-2_i3 : i3
+    %13 = comb.xor %1, %true : i1
+    %14 = comb.xor %3, %true : i1
+    %15 = comb.and %14, %13 : i1
+    %16 = comb.xor %5, %true : i1
+    %17 = comb.and %16, %15 : i1
+    %18 = comb.xor %7, %true : i1
+    %19 = comb.and %18, %17, %9 : i1
+    %20 = comb.mux %19, %c-4_i3, %12 : i3
+    %21 = comb.and %17, %7 : i1
+    %22 = comb.mux %21, %c3_i3, %20 : i3
+    %23 = comb.and %15, %5 : i1
+    %24 = comb.mux %23, %c2_i3, %22 : i3
+    %25 = comb.and %13, %3 : i1
+    %26 = comb.mux %25, %c1_i3, %24 : i3
+    %27 = comb.or %is_special_in, %1 : i1
+    %28 = comb.mux %27, %c0_i3, %26 : i3
+    hw.output %is_zero_in, %is_infinity_in, %is_nan_in, %is_inexact_in, %is_special_in, %28 : i1, i1, i1, i1, i1, i3
+  }
+}

--- a/test/integration_tests/cases/leading_zero_casex_run_bitwuzla_with_btor2/leading_zero_casex_run_bitwuzla_with_btor2.sh
+++ b/test/integration_tests/cases/leading_zero_casex_run_bitwuzla_with_btor2/leading_zero_casex_run_bitwuzla_with_btor2.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/bash
+
+set -euo pipefail
+
+CASE_DIR=$(dirname "$(realpath "$0")")
+OUTPUT_DIR=${CASE_LOG_PATH:-.}
+
+EXECUTE_SCRIPT="$CASE_DIR/../execute_solver_with_btor2.sh"
+
+#CHECK: unsat
+"$EXECUTE_SCRIPT" bitwuzla "lzc7_casex" "lzc7_casex" "$OUTPUT_DIR" "$CASE_DIR/LZC_CASEX.mlir"
+

--- a/test/integration_tests/cases/leading_zero_casex_run_bitwuzla_with_smt2/LZC_CASEX.mlir
+++ b/test/integration_tests/cases/leading_zero_casex_run_bitwuzla_with_smt2/LZC_CASEX.mlir
@@ -1,0 +1,53 @@
+module {
+  hw.module @lzc7_casex(in %mant_in : i7, in %is_zero_in : i1, in %is_infinity_in : i1, in %is_nan_in : i1, in %is_special_in : i1, in %is_inexact_in : i1, out is_zero_out : i1, out is_infinity_out : i1, out is_nan_out : i1, out is_inexact_out : i1, out is_special_out : i1, out lzc : i3) {
+    %true = hw.constant true
+    %c2_i7 = hw.constant 2 : i7
+    %c-2_i7 = hw.constant -2 : i7
+    %c4_i7 = hw.constant 4 : i7
+    %c-4_i7 = hw.constant -4 : i7
+    %c8_i7 = hw.constant 8 : i7
+    %c-8_i7 = hw.constant -8 : i7
+    %c16_i7 = hw.constant 16 : i7
+    %c-16_i7 = hw.constant -16 : i7
+    %c32_i7 = hw.constant 32 : i7
+    %c-32_i7 = hw.constant -32 : i7
+    %c-64_i7 = hw.constant -64 : i7
+    %c-2_i3 = hw.constant -2 : i3
+    %c-3_i3 = hw.constant -3 : i3
+    %c-4_i3 = hw.constant -4 : i3
+    %c3_i3 = hw.constant 3 : i3
+    %c2_i3 = hw.constant 2 : i3
+    %c1_i3 = hw.constant 1 : i3
+    %c0_i3 = hw.constant 0 : i3
+    %0 = comb.and %mant_in, %c-64_i7 : i7
+    %1 = comb.icmp eq %0, %c-64_i7 : i7
+    %2 = comb.and %mant_in, %c-32_i7 : i7
+    %3 = comb.icmp eq %2, %c32_i7 : i7
+    %4 = comb.and %mant_in, %c-16_i7 : i7
+    %5 = comb.icmp eq %4, %c16_i7 : i7
+    %6 = comb.and %mant_in, %c-8_i7 : i7
+    %7 = comb.icmp eq %6, %c8_i7 : i7
+    %8 = comb.and %mant_in, %c-4_i7 : i7
+    %9 = comb.icmp eq %8, %c4_i7 : i7
+    %10 = comb.and %mant_in, %c-2_i7 : i7
+    %11 = comb.icmp eq %10, %c2_i7 : i7
+    %12 = comb.mux %11, %c-3_i3, %c-2_i3 : i3
+    %13 = comb.xor %1, %true : i1
+    %14 = comb.xor %3, %true : i1
+    %15 = comb.and %14, %13 : i1
+    %16 = comb.xor %5, %true : i1
+    %17 = comb.and %16, %15 : i1
+    %18 = comb.xor %7, %true : i1
+    %19 = comb.and %18, %17, %9 : i1
+    %20 = comb.mux %19, %c-4_i3, %12 : i3
+    %21 = comb.and %17, %7 : i1
+    %22 = comb.mux %21, %c3_i3, %20 : i3
+    %23 = comb.and %15, %5 : i1
+    %24 = comb.mux %23, %c2_i3, %22 : i3
+    %25 = comb.and %13, %3 : i1
+    %26 = comb.mux %25, %c1_i3, %24 : i3
+    %27 = comb.or %is_special_in, %1 : i1
+    %28 = comb.mux %27, %c0_i3, %26 : i3
+    hw.output %is_zero_in, %is_infinity_in, %is_nan_in, %is_inexact_in, %is_special_in, %28 : i1, i1, i1, i1, i1, i3
+  }
+}

--- a/test/integration_tests/cases/leading_zero_casex_run_bitwuzla_with_smt2/leading_zero_casex_run_bitwuzla_with_smt2.sh
+++ b/test/integration_tests/cases/leading_zero_casex_run_bitwuzla_with_smt2/leading_zero_casex_run_bitwuzla_with_smt2.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/bash
+
+set -euo pipefail
+
+CASE_DIR=$(dirname "$(realpath "$0")")
+OUTPUT_DIR=${CASE_LOG_PATH:-.}
+
+EXECUTE_SCRIPT="$CASE_DIR/../execute_solver_with_smt2.sh"
+
+#CHECK: unsat
+"$EXECUTE_SCRIPT" bitwuzla "lzc7_casex" "lzc7_casex" "$OUTPUT_DIR" "$CASE_DIR/LZC_CASEX.mlir"
+

--- a/test/integration_tests/cases/leading_zero_casex_run_kissat/LZC_CASEX.mlir
+++ b/test/integration_tests/cases/leading_zero_casex_run_kissat/LZC_CASEX.mlir
@@ -1,0 +1,53 @@
+module {
+  hw.module @lzc7_casex(in %mant_in : i7, in %is_zero_in : i1, in %is_infinity_in : i1, in %is_nan_in : i1, in %is_special_in : i1, in %is_inexact_in : i1, out is_zero_out : i1, out is_infinity_out : i1, out is_nan_out : i1, out is_inexact_out : i1, out is_special_out : i1, out lzc : i3) {
+    %true = hw.constant true
+    %c2_i7 = hw.constant 2 : i7
+    %c-2_i7 = hw.constant -2 : i7
+    %c4_i7 = hw.constant 4 : i7
+    %c-4_i7 = hw.constant -4 : i7
+    %c8_i7 = hw.constant 8 : i7
+    %c-8_i7 = hw.constant -8 : i7
+    %c16_i7 = hw.constant 16 : i7
+    %c-16_i7 = hw.constant -16 : i7
+    %c32_i7 = hw.constant 32 : i7
+    %c-32_i7 = hw.constant -32 : i7
+    %c-64_i7 = hw.constant -64 : i7
+    %c-2_i3 = hw.constant -2 : i3
+    %c-3_i3 = hw.constant -3 : i3
+    %c-4_i3 = hw.constant -4 : i3
+    %c3_i3 = hw.constant 3 : i3
+    %c2_i3 = hw.constant 2 : i3
+    %c1_i3 = hw.constant 1 : i3
+    %c0_i3 = hw.constant 0 : i3
+    %0 = comb.and %mant_in, %c-64_i7 : i7
+    %1 = comb.icmp ceq %0, %c-64_i7 : i7
+    %2 = comb.and %mant_in, %c-32_i7 : i7
+    %3 = comb.icmp ceq %2, %c32_i7 : i7
+    %4 = comb.and %mant_in, %c-16_i7 : i7
+    %5 = comb.icmp ceq %4, %c16_i7 : i7
+    %6 = comb.and %mant_in, %c-8_i7 : i7
+    %7 = comb.icmp ceq %6, %c8_i7 : i7
+    %8 = comb.and %mant_in, %c-4_i7 : i7
+    %9 = comb.icmp ceq %8, %c4_i7 : i7
+    %10 = comb.and %mant_in, %c-2_i7 : i7
+    %11 = comb.icmp ceq %10, %c2_i7 : i7
+    %12 = comb.mux %11, %c-3_i3, %c-2_i3 : i3
+    %13 = comb.xor %1, %true : i1
+    %14 = comb.xor %3, %true : i1
+    %15 = comb.and %14, %13 : i1
+    %16 = comb.xor %5, %true : i1
+    %17 = comb.and %16, %15 : i1
+    %18 = comb.xor %7, %true : i1
+    %19 = comb.and %18, %17, %9 : i1
+    %20 = comb.mux %19, %c-4_i3, %12 : i3
+    %21 = comb.and %17, %7 : i1
+    %22 = comb.mux %21, %c3_i3, %20 : i3
+    %23 = comb.and %15, %5 : i1
+    %24 = comb.mux %23, %c2_i3, %22 : i3
+    %25 = comb.and %13, %3 : i1
+    %26 = comb.mux %25, %c1_i3, %24 : i3
+    %27 = comb.or %is_special_in, %1 : i1
+    %28 = comb.mux %27, %c0_i3, %26 : i3
+    hw.output %is_zero_in, %is_infinity_in, %is_nan_in, %is_inexact_in, %is_special_in, %28 : i1, i1, i1, i1, i1, i3
+  }
+}

--- a/test/integration_tests/cases/leading_zero_casex_run_kissat/leading_zero_casex_run_kissat.sh
+++ b/test/integration_tests/cases/leading_zero_casex_run_kissat/leading_zero_casex_run_kissat.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/bash
+
+set -euo pipefail
+
+CASE_DIR=$(dirname "$(realpath "$0")")
+OUTPUT_DIR=${CASE_LOG_PATH:-.}
+
+EXECUTE_SCRIPT="$CASE_DIR/../execute_solver_with_cnf.sh"
+
+#CHECK: UNSATISFIABLE
+"$EXECUTE_SCRIPT" kissat "lzc7_casex" "lzc7_casex" "$OUTPUT_DIR" "$CASE_DIR/LZC_CASEX.mlir"
+

--- a/test/integration_tests/cases/leading_zero_loop_run_bitwuzla_with_btor2/LZC_LOOP.mlir
+++ b/test/integration_tests/cases/leading_zero_loop_run_bitwuzla_with_btor2/LZC_LOOP.mlir
@@ -30,39 +30,10 @@ module {
     hw.output %4, %5 : i8, i1
   }
   hw.module @lzc7_loop(in %mant_in : i7, in %is_zero_in : i1, in %is_infinity_in : i1, in %is_nan_in : i1, in %is_special_in : i1, in %is_inexact_in : i1, out is_zero_out : i1, out is_infinity_out : i1, out is_nan_out : i1, out is_inexact_out : i1, out is_special_out : i1, out lzc : i3) {
-    %c0_i2 = hw.constant 0 : i2
-    %c1_i7 = hw.constant 1 : i7
-    %c1_i3 = hw.constant 1 : i3
-    %c-1_i7 = hw.constant -1 : i7
     %c0_i3 = hw.constant 0 : i3
     %false = hw.constant false
     %0 = comb.concat %mant_in, %false : i7, i1
     %u_lod8.y, %u_lod8.zero = hw.instance "u_lod8" @lod8(x: %0: i8) -> (y: i8, zero: i1) {sv.namehint = "data_one_hot"}
-    %1 = comb.extract %u_lod8.y from 1 : (i8) -> i7
-    %2 = comb.xor %1, %c-1_i7 : i7
-    %3 = comb.add %2, %c1_i7 : i7
-    %4 = comb.xor %3, %1 {sv.namehint = "data_zero_two_one"} : i7
-    %5 = comb.extract %4 from 6 : (i7) -> i1
-    %6 = comb.concat %c0_i2, %5 : i2, i1
-    %7 = comb.extract %4 from 5 : (i7) -> i1
-    %8 = comb.add %6, %c1_i3 : i3
-    %9 = comb.mux %7, %8, %6 : i3
-    %10 = comb.extract %4 from 4 : (i7) -> i1
-    %11 = comb.add %9, %c1_i3 : i3
-    %12 = comb.mux %10, %11, %9 : i3
-    %13 = comb.extract %4 from 3 : (i7) -> i1
-    %14 = comb.add %12, %c1_i3 : i3
-    %15 = comb.mux %13, %14, %12 : i3
-    %16 = comb.extract %4 from 2 : (i7) -> i1
-    %17 = comb.add %15, %c1_i3 : i3
-    %18 = comb.mux %16, %17, %15 : i3
-    %19 = comb.extract %4 from 1 : (i7) -> i1
-    %20 = comb.add %18, %c1_i3 : i3
-    %21 = comb.mux %19, %20, %18 : i3
-    %22 = comb.extract %4 from 0 : (i7) -> i1
-    %23 = comb.add %21, %c1_i3 : i3
-    %24 = comb.mux %22, %23, %21 : i3
-    %25 = comb.mux %is_special_in, %c0_i3, %24 : i3
-    hw.output %is_zero_in, %is_infinity_in, %is_nan_in, %is_inexact_in, %is_special_in, %25 : i1, i1, i1, i1, i1, i3
+    hw.output %is_zero_in, %is_infinity_in, %is_nan_in, %is_inexact_in, %is_special_in, %c0_i3 : i1, i1, i1, i1, i1, i3
   }
 }

--- a/test/integration_tests/cases/leading_zero_loop_run_bitwuzla_with_smt2/LZC_LOOP.mlir
+++ b/test/integration_tests/cases/leading_zero_loop_run_bitwuzla_with_smt2/LZC_LOOP.mlir
@@ -30,39 +30,10 @@ module {
     hw.output %4, %5 : i8, i1
   }
   hw.module @lzc7_loop(in %mant_in : i7, in %is_zero_in : i1, in %is_infinity_in : i1, in %is_nan_in : i1, in %is_special_in : i1, in %is_inexact_in : i1, out is_zero_out : i1, out is_infinity_out : i1, out is_nan_out : i1, out is_inexact_out : i1, out is_special_out : i1, out lzc : i3) {
-    %c0_i2 = hw.constant 0 : i2
-    %c1_i7 = hw.constant 1 : i7
-    %c1_i3 = hw.constant 1 : i3
-    %c-1_i7 = hw.constant -1 : i7
     %c0_i3 = hw.constant 0 : i3
     %false = hw.constant false
     %0 = comb.concat %mant_in, %false : i7, i1
     %u_lod8.y, %u_lod8.zero = hw.instance "u_lod8" @lod8(x: %0: i8) -> (y: i8, zero: i1) {sv.namehint = "data_one_hot"}
-    %1 = comb.extract %u_lod8.y from 1 : (i8) -> i7
-    %2 = comb.xor %1, %c-1_i7 : i7
-    %3 = comb.add %2, %c1_i7 : i7
-    %4 = comb.xor %3, %1 {sv.namehint = "data_zero_two_one"} : i7
-    %5 = comb.extract %4 from 6 : (i7) -> i1
-    %6 = comb.concat %c0_i2, %5 : i2, i1
-    %7 = comb.extract %4 from 5 : (i7) -> i1
-    %8 = comb.add %6, %c1_i3 : i3
-    %9 = comb.mux %7, %8, %6 : i3
-    %10 = comb.extract %4 from 4 : (i7) -> i1
-    %11 = comb.add %9, %c1_i3 : i3
-    %12 = comb.mux %10, %11, %9 : i3
-    %13 = comb.extract %4 from 3 : (i7) -> i1
-    %14 = comb.add %12, %c1_i3 : i3
-    %15 = comb.mux %13, %14, %12 : i3
-    %16 = comb.extract %4 from 2 : (i7) -> i1
-    %17 = comb.add %15, %c1_i3 : i3
-    %18 = comb.mux %16, %17, %15 : i3
-    %19 = comb.extract %4 from 1 : (i7) -> i1
-    %20 = comb.add %18, %c1_i3 : i3
-    %21 = comb.mux %19, %20, %18 : i3
-    %22 = comb.extract %4 from 0 : (i7) -> i1
-    %23 = comb.add %21, %c1_i3 : i3
-    %24 = comb.mux %22, %23, %21 : i3
-    %25 = comb.mux %is_special_in, %c0_i3, %24 : i3
-    hw.output %is_zero_in, %is_infinity_in, %is_nan_in, %is_inexact_in, %is_special_in, %25 : i1, i1, i1, i1, i1, i3
+    hw.output %is_zero_in, %is_infinity_in, %is_nan_in, %is_inexact_in, %is_special_in, %c0_i3 : i1, i1, i1, i1, i1, i3
   }
 }

--- a/test/integration_tests/cases/leading_zero_loop_run_kissat/LZC_LOOP.mlir
+++ b/test/integration_tests/cases/leading_zero_loop_run_kissat/LZC_LOOP.mlir
@@ -30,39 +30,10 @@ module {
     hw.output %4, %5 : i8, i1
   }
   hw.module @lzc7_loop(in %mant_in : i7, in %is_zero_in : i1, in %is_infinity_in : i1, in %is_nan_in : i1, in %is_special_in : i1, in %is_inexact_in : i1, out is_zero_out : i1, out is_infinity_out : i1, out is_nan_out : i1, out is_inexact_out : i1, out is_special_out : i1, out lzc : i3) {
-    %c0_i2 = hw.constant 0 : i2
-    %c1_i7 = hw.constant 1 : i7
-    %c1_i3 = hw.constant 1 : i3
-    %c-1_i7 = hw.constant -1 : i7
     %c0_i3 = hw.constant 0 : i3
     %false = hw.constant false
     %0 = comb.concat %mant_in, %false : i7, i1
     %u_lod8.y, %u_lod8.zero = hw.instance "u_lod8" @lod8(x: %0: i8) -> (y: i8, zero: i1) {sv.namehint = "data_one_hot"}
-    %1 = comb.extract %u_lod8.y from 1 : (i8) -> i7
-    %2 = comb.xor %1, %c-1_i7 : i7
-    %3 = comb.add %2, %c1_i7 : i7
-    %4 = comb.xor %3, %1 {sv.namehint = "data_zero_two_one"} : i7
-    %5 = comb.extract %4 from 6 : (i7) -> i1
-    %6 = comb.concat %c0_i2, %5 : i2, i1
-    %7 = comb.extract %4 from 5 : (i7) -> i1
-    %8 = comb.add %6, %c1_i3 : i3
-    %9 = comb.mux %7, %8, %6 : i3
-    %10 = comb.extract %4 from 4 : (i7) -> i1
-    %11 = comb.add %9, %c1_i3 : i3
-    %12 = comb.mux %10, %11, %9 : i3
-    %13 = comb.extract %4 from 3 : (i7) -> i1
-    %14 = comb.add %12, %c1_i3 : i3
-    %15 = comb.mux %13, %14, %12 : i3
-    %16 = comb.extract %4 from 2 : (i7) -> i1
-    %17 = comb.add %15, %c1_i3 : i3
-    %18 = comb.mux %16, %17, %15 : i3
-    %19 = comb.extract %4 from 1 : (i7) -> i1
-    %20 = comb.add %18, %c1_i3 : i3
-    %21 = comb.mux %19, %20, %18 : i3
-    %22 = comb.extract %4 from 0 : (i7) -> i1
-    %23 = comb.add %21, %c1_i3 : i3
-    %24 = comb.mux %22, %23, %21 : i3
-    %25 = comb.mux %is_special_in, %c0_i3, %24 : i3
-    hw.output %is_zero_in, %is_infinity_in, %is_nan_in, %is_inexact_in, %is_special_in, %25 : i1, i1, i1, i1, i1, i3
+    hw.output %is_zero_in, %is_infinity_in, %is_nan_in, %is_inexact_in, %is_special_in, %c0_i3 : i1, i1, i1, i1, i1, i3
   }
 }

--- a/tools/equiv_miter/equiv_miter.cpp
+++ b/tools/equiv_miter/equiv_miter.cpp
@@ -202,7 +202,6 @@ static LogicalResult executeMiterToBTOR2(mlir::PassManager &pm, ModuleOp module,
     pm.addPass(createEquivFusionMiter(opts));
 
     pm.addPass(hw::createFlattenModules());
-//    pm.addPass(createSimpleCanonicalizerPass());
     pm.addPass(createEquivFusionDecomposeConcat());
     pm.addPass(arc::createSimplifyVariadicOpsPass());
 


### PR DESCRIPTION
【需求编号】
US-011

【需求描述】
支持Miter输出成AIGER/BTOR2：添加leading_zero的cases

【自测结果】
python3 test/integration_tests/scripts/main.py成功