### PR TITLE
[Frontend][US-012]Support HLS Flow that Converts Affine/Scf/Arith to …

### DIFF
--- a/include/circt-passes/CMakeLists.txt
+++ b/include/circt-passes/CMakeLists.txt
@@ -1,2 +1,3 @@
 add_subdirectory(Miter)
 add_subdirectory(DecomposeConcat)
+add_subdirectory(FuncToHWModule)

--- a/include/circt-passes/FuncToHWModule/CMakeLists.txt
+++ b/include/circt-passes/FuncToHWModule/CMakeLists.txt
@@ -1,0 +1,11 @@
+# 指定使用的td文件
+set(LLVM_TARGET_DEFINITIONS Passes.td) 
+
+# 生成命令基类实现，命令创建函数，命令注册函数，命令组注册函数的Passes.h.inc文件。-name指定命令组名称
+mlir_tablegen(Passes.h.inc -gen-pass-decls -name EquivFusionFuncToHWModule) 
+
+# 生成供其他语言调用的capi定义文件
+mlir_tablegen(EquivFusionFuncToHWModule.capi.h.inc -gen-pass-capi-header --prefix EquivFusionFuncToHWModule)
+mlir_tablegen(EquivFusionFuncToHWModule.capi.cpp.inc -gen-pass-capi-impl --prefix EquivFusionFuncToHWModule)
+
+add_public_tablegen_target(FuncToHWModuleIncGen)

--- a/include/circt-passes/FuncToHWModule/Passes.h
+++ b/include/circt-passes/FuncToHWModule/Passes.h
@@ -1,0 +1,12 @@
+#pragma once
+
+#include "mlir/Pass/Pass.h"
+
+namespace circt {
+
+/// Generate the code for registering passes.
+#define GEN_PASS_DECL_FUNCTOHWMODULE
+#define GEN_PASS_REGISTRATION
+#include "circt-passes/FuncToHWModule/Passes.h.inc"
+
+}

--- a/include/circt-passes/FuncToHWModule/Passes.td
+++ b/include/circt-passes/FuncToHWModule/Passes.td
@@ -1,0 +1,17 @@
+#ifndef EQUIVFUSION_FUNC_TO_HW_MODULE_PASSES_TD
+#define EQUIVFUSION_FUNC_TO_HW_MODULE_PASSES_TD
+
+include "mlir/Pass/PassBase.td"
+
+def FuncToHWModule : Pass<"func-to-hw-module", "mlir::ModuleOp"> { 
+    let summary = "Convert func.func to hw.module";
+
+    let description = [{
+        This Pass converts operation 'func.func' to 'hw.module'.
+    }];
+
+    let dependentDialects = ["mlir::func::FuncDialect", "circt::hw::HWDialect", "mlir::cf::ControlFlowDialect", "circt::comb::CombDialect"];
+}
+
+#endif // EQUIVFUSION_FUNC_TO_HW_MODULE_PASSES_TD
+

--- a/infrastructure/circt-passes/CMakeLists.txt
+++ b/infrastructure/circt-passes/CMakeLists.txt
@@ -1,2 +1,3 @@
 add_subdirectory(Miter)
 add_subdirectory(DecomposeConcat)
+add_subdirectory(FuncToHWModule)

--- a/infrastructure/circt-passes/FuncToHWModule/CMakeLists.txt
+++ b/infrastructure/circt-passes/FuncToHWModule/CMakeLists.txt
@@ -1,0 +1,14 @@
+add_circt_library(FuncToHWModule
+    func_to_hw_module.cpp
+
+    DEPENDS
+    FuncToHWModuleIncGen
+
+    LINK_LIBS PUBLIC
+    MLIRControlFlowDialect
+    MLIRFuncDialect
+    CIRCTHW
+    CIRCTComb
+)
+
+

--- a/infrastructure/circt-passes/FuncToHWModule/func_to_hw_module.cpp
+++ b/infrastructure/circt-passes/FuncToHWModule/func_to_hw_module.cpp
@@ -1,0 +1,507 @@
+#include "circt-passes/FuncToHWModule/Passes.h"
+#include "circt/Dialect/HW/HWOps.h"
+#include "circt/Dialect/Comb/CombOps.h"
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/Dialect/ControlFlow/IR/ControlFlowOps.h"
+#include "mlir/IR/Builders.h"
+#include "mlir/IR/IRMapping.h"
+#include "mlir/IR/Matchers.h"
+#include "llvm/ADT/STLExtras.h"
+#include "llvm/ADT/PostOrderIterator.h"
+#include "llvm/Support/Casting.h"
+
+namespace circt {
+#define GEN_PASS_DEF_FUNCTOHWMODULE
+#include "circt-passes/FuncToHWModule/Passes.h.inc"
+} // namespace circt
+ 
+
+namespace {
+/// A helper struct that tracks a boolean condition as either a constant false,
+/// constant true, or an SSA value.
+struct Condition {
+    Condition() {}
+    Condition(mlir::Value value) : pair(value, 0) {
+      if (value) {
+        if (mlir::matchPattern(value, mlir::m_One()))
+          *this = Condition(true);
+        if (mlir::matchPattern(value, mlir::m_Zero()))
+          *this = Condition(false);
+      }
+    }
+    Condition(bool konst) : pair(nullptr, konst ? 1 : 2) {}
+  
+    explicit operator bool() const {
+      return pair.getPointer() != nullptr || pair.getInt() != 0;
+    }
+  
+    bool isTrue() const { return !pair.getPointer() && pair.getInt() == 1; }
+    bool isFalse() const { return !pair.getPointer() && pair.getInt() == 2; }
+    mlir::Value getValue() const { return pair.getPointer(); }
+  
+    /// Turn this condition into an SSA value, creating an `hw.constant` if the
+    /// condition is a constant.
+    mlir::Value materialize(mlir::OpBuilder &builder, mlir::Location loc) const {
+      if (isTrue())
+        return circt::hw::ConstantOp::create(builder, loc, llvm::APInt(1, 1));
+      if (isFalse())
+        return circt::hw::ConstantOp::create(builder, loc, llvm::APInt(1, 0));
+      return pair.getPointer();
+    }
+  
+    Condition orWith(Condition other, mlir::OpBuilder &builder) const {
+      if (isTrue() || other.isTrue())
+        return true;
+      if (isFalse())
+        return other;
+      if (other.isFalse())
+        return *this;
+      return builder.createOrFold<circt::comb::OrOp>(getValue().getLoc(), getValue(),
+                                              other.getValue());
+    }
+  
+    Condition andWith(Condition other, mlir::OpBuilder &builder) const {
+      if (isFalse() || other.isFalse())
+        return false;
+      if (isTrue())
+        return other;
+      if (other.isTrue())
+        return *this;
+      return builder.createOrFold<circt::comb::AndOp>(getValue().getLoc(), getValue(),
+                                               other.getValue());
+    }
+  
+    Condition inverted(mlir::OpBuilder &builder) const {
+      if (isTrue())
+        return false;
+      if (isFalse())
+        return true;
+      return circt::comb::createOrFoldNot(getValue().getLoc(), getValue(), builder);
+    }
+  
+  private:
+    llvm::PointerIntPair<mlir::Value, 2> pair;
+  };
+
+
+
+struct CFRemover {
+  CFRemover(mlir::Region &region) : region(region) {}
+  mlir::LogicalResult run();
+
+  /// The region within which we are removing control flow.
+  mlir::Region &region;
+  /// The blocks in the region, sorted such that a block's predecessors appear
+  /// in the list before the block itself.
+  llvm::SmallVector<mlir::Block *> sortedBlocks;
+  /// The dominance information for the region.
+  mlir::DominanceInfo domInfo;
+};
+
+
+struct FuncToHWModulePass : public circt::impl::FuncToHWModuleBase<FuncToHWModulePass> {
+    using circt::impl::FuncToHWModuleBase<FuncToHWModulePass>::FuncToHWModuleBase;
+
+    void runOnOperation() override;
+private:
+
+    circt::hw::HWModuleOp
+    buildHWModuleOPFromFuncOP(mlir::OpBuilder &builder, mlir::func::FuncOp funcOp);
+
+    mlir::LogicalResult
+    copyOpFromFuncToHWModule(mlir::OpBuilder &builder, mlir::func::FuncOp funcOp, circt::hw::HWModuleOp hwModuleOp);
+
+    mlir::LogicalResult convertFuncToHWModule(mlir::func::FuncOp funcOp);
+
+    mlir::LogicalResult
+    removeControlFlowFromFuncOp(mlir::func::FuncOp funcOp);
+};
+
+} // namespace
+
+static Condition getBranchDecisionsFromDominatorToTarget(
+    mlir::OpBuilder &builder, mlir::Block *dominator, mlir::Block *target,
+    llvm::SmallDenseMap<std::pair<mlir::Block *, mlir::Block *>, Condition> &decisions) {
+  if (auto decision = decisions.lookup({dominator, target}))
+    return decision;
+
+  llvm::SmallPtrSet<mlir::Block *, 8> visitedBlocks;
+  visitedBlocks.insert(dominator); // stop at the dominator
+  if (auto &decision = decisions[{dominator, dominator}]; !decision)
+    decision = Condition(true);
+
+  // Traverse the blocks in inverse post order. This ensures that we are
+  // visiting all of a block's predecessors before we visit the block itself.
+  // This allows us to first compute the decision leading control flow to each
+  // of the predecessors, such that the current block can then just combine the
+  // predecessor decisions.
+  for (auto *block : llvm::inverse_post_order_ext(target, visitedBlocks)) {
+    auto merged = Condition(false);
+    for (auto *pred : block->getPredecessors()) {
+      auto predDecision = decisions.lookup({dominator, pred});
+      assert(predDecision);
+      if (pred->getTerminator()->getNumSuccessors() != 1) {
+        auto condBr = llvm::cast<mlir::cf::CondBranchOp>(pred->getTerminator());
+        if (condBr.getTrueDest() == condBr.getFalseDest()) {
+          merged = merged.orWith(predDecision, builder);
+        } else {
+          auto cond = Condition(condBr.getCondition());
+          if (condBr.getFalseDest() == block)
+            cond = cond.inverted(builder);
+          merged = merged.orWith(cond.andWith(predDecision, builder), builder);
+        }
+      } else {
+        merged = merged.orWith(predDecision, builder);
+      }
+    }
+    assert(merged);
+    decisions.insert({{dominator, block}, merged});
+  }
+
+  return decisions.lookup({dominator, target});
+}
+
+mlir::LogicalResult
+CFRemover::run() {
+    // Establish a topological order of the blocks in the region. Give up if we
+    // detect a control flow cycle. Also take note of all ReturnOp, such that we
+    // can combine them into a single return block later.
+
+    llvm::SmallVector<mlir::func::ReturnOp, 2> returnOps;
+    llvm::SmallPtrSet<mlir::Block *, 8> visitedBlocks, ipoSet;
+
+    for (auto &block : region) {
+        for (auto *ipoBlock : llvm::inverse_post_order_ext(&block, ipoSet)) {
+          if (!llvm::all_of(ipoBlock->getPredecessors(), [&](auto *pred) {
+                return visitedBlocks.contains(pred);
+              })) {
+            llvm::errs() << "Loop detected, giving up\n";
+            return mlir::failure();
+          }
+          visitedBlocks.insert(ipoBlock);
+          sortedBlocks.push_back(ipoBlock);
+        }
+    
+        // Give up if there are any side-effecting ops in the region.
+        for (auto &op : block) {
+          if (!mlir::isMemoryEffectFree(&op)) {
+            llvm::errs() << "Has side effects, giving up\n";
+            return mlir::failure();
+          }
+        }
+    
+        // Check that we know what to do with all terminators.
+        if (!llvm::isa<mlir::func::ReturnOp, mlir::cf::BranchOp, mlir::cf::CondBranchOp>(block.getTerminator())) {
+          llvm::errs() << "Has unsupported terminator " << block.getTerminator()->getName() << ", giving up\n";
+            return mlir::failure();
+        }
+    
+        // Keep track of return ops.
+        if (auto returnOp = llvm::dyn_cast<mlir::func::ReturnOp>(block.getTerminator()))
+            returnOps.push_back(returnOp);
+    }
+
+    // If there are multiple return ops, factor them out into a single return block.
+    auto returnOp = returnOps[0];
+    if (returnOps.size() > 1) {
+        mlir::OpBuilder builder(region.getContext());
+        llvm::SmallVector<mlir::Location> locs(returnOps[0].getNumOperands(), region.getLoc());
+        auto *returnBlock = builder.createBlock(&region, region.end(),
+                                               returnOps[0].getOperandTypes(), locs);
+        sortedBlocks.push_back(returnBlock);
+        returnOp =
+            mlir::func::ReturnOp::create(builder, region.getLoc(), returnBlock->getArguments());
+        for (auto returnOp : returnOps) {
+          builder.setInsertionPoint(returnOp);
+          mlir::cf::BranchOp::create(builder, returnOp.getLoc(), returnBlock,
+                               returnOp.getOperands());
+          returnOp.erase();
+        }
+    }
+
+    // Compute the dominance info for this region.
+    domInfo = mlir::DominanceInfo(region.getParentOp());
+
+    // Move operations into the entry block, replacing block arguments with
+    // multiplexers as we go. The block order guarantees that we visit a block's
+    // predecessors before we visit the block itself.
+
+    llvm::SmallDenseMap<std::pair<mlir::Block *, mlir::Block *>, Condition> decisionCache;
+    auto *entryBlock = sortedBlocks.front();
+
+    for (auto *block : sortedBlocks) {
+        if (!domInfo.isReachableFromEntry(block))
+            continue;
+
+        // Find the nearest common dominator block of all predecessors. Any block
+        // arguments reaching the current block will only depend on control flow
+        // decisions between this dominator block and the current block.
+        auto *domBlock = block;
+        for (auto *pred : block->getPredecessors())
+            if (domInfo.isReachableFromEntry(pred))
+                domBlock = domInfo.findNearestCommonDominator(domBlock, pred);
+        
+        // Convert the block arguments into multiplexers.
+        mlir::OpBuilder builder(entryBlock->getTerminator());
+        mlir::SmallVector<mlir::Value> mergedArgs;
+        mlir::SmallPtrSet<mlir::Block *, 4> seenPreds;
+
+        for (auto *pred : block->getPredecessors()) {
+            // A block may be listed multiple times in the predecessors.
+            if (!seenPreds.insert(pred).second)
+                continue;
+
+            // Only consider values coming from reachable predecessors.
+            if (!domInfo.isReachableFromEntry(pred))
+                continue;
+            
+            // Helper function to create a multiplexer between the current
+            // `mergedArgs` and a new set of `args`, where the new args are picked if
+            // `cond` is true and control flows from `domBlock` to `pred`. The
+            // condition may be null, in which case the mux will directly use the
+            // branch decisions that lead from `domBlock` to `pred`.
+
+            auto mergeArgs = [&](mlir::ValueRange args, Condition cond, bool invCond) {
+                if (mergedArgs.empty()) {
+                    mergedArgs = args;
+                    return;
+                }
+                auto decision = getBranchDecisionsFromDominatorToTarget(
+                    builder, domBlock, pred, decisionCache);
+                if (cond) {
+                    if (invCond)
+                        cond = cond.inverted(builder);
+                    decision = decision.andWith(cond, builder);
+                }
+                for (auto [mergedArg, arg] : llvm::zip(mergedArgs, args)) {
+                  if (decision.isTrue())
+                      mergedArg = arg;
+                  else if (decision.isFalse())
+                      continue;
+                  else
+                    mergedArg = builder.createOrFold<circt::comb::MuxOp>(
+                        arg.getLoc(), decision.materialize(builder, arg.getLoc()), arg,
+                        mergedArg);
+                }
+            };
+
+            // Handle the different terminators that we support.
+            if (auto condBrOp = llvm::dyn_cast<mlir::cf::CondBranchOp>(pred->getTerminator())) {
+                if (condBrOp.getTrueDest() == condBrOp.getFalseDest()) {
+                  // Both destinations lead to the current block. Insert a mux to
+                  // collapse the destination operands and then treat this as an
+                  // unconditional branch to the current block.
+                  llvm::SmallVector<mlir::Value> mergedOperands;
+                  mergedOperands.reserve(block->getNumArguments());
+                  for (auto [trueArg, falseArg] :
+                       llvm::zip(condBrOp.getTrueDestOperands(),
+                                 condBrOp.getFalseDestOperands())) {
+                    mergedOperands.push_back(builder.createOrFold<circt::comb::MuxOp>(
+                        trueArg.getLoc(), condBrOp.getCondition(), trueArg, falseArg));
+                  }
+                  mergeArgs(mergedOperands, mlir::Value{}, false);
+                } else if (condBrOp.getTrueDest() == block) {
+                  // The branch leads to the current block if the condition is true.
+                  mergeArgs(condBrOp.getTrueDestOperands(), condBrOp.getCondition(),
+                            false);
+                } else {
+                  // The branch leads to the current block if the condition is false.
+                  mergeArgs(condBrOp.getFalseDestOperands(), condBrOp.getCondition(),
+                            true);
+                }
+            } else {
+                auto brOp = llvm::cast<mlir::cf::BranchOp>(pred->getTerminator());
+                mergeArgs(brOp.getDestOperands(), mlir::Value{}, false);
+            }
+        } 
+
+        for (auto [blockArg, mergedArg] :
+               llvm::zip(block->getArguments(), mergedArgs))
+            blockArg.replaceAllUsesWith(mergedArg);
+   
+       // Move all ops except for the terminator into the entry block.
+       if (block != entryBlock)
+         entryBlock->getOperations().splice(--entryBlock->end(),
+                                            block->getOperations(), block->begin(),
+                                            --block->end());
+
+    }
+
+    // Move the return op into the entry block, replacing the original terminator.
+    if (returnOp != entryBlock->getTerminator()) {
+        returnOp->moveBefore(entryBlock->getTerminator());
+        entryBlock->getTerminator()->erase();
+    }
+
+    // Remove all blocks except for the entry block. We first clear all operations
+    // in the blocks such that the blocks have no more uses in branch ops. Then we
+    // remove the blocks themselves in a second pass.
+     for (auto *block : sortedBlocks)
+        if (block != entryBlock)
+            block->clear();
+    for (auto *block : sortedBlocks)
+        if (block != entryBlock)
+            block->erase();
+
+    return mlir::success();
+}
+
+circt::hw::HWModuleOp 
+FuncToHWModulePass::buildHWModuleOPFromFuncOP(mlir::OpBuilder &builder, mlir::func::FuncOp funcOp) { 
+    builder.setInsertionPointAfter(funcOp);
+    mlir::Location loc = funcOp.getLoc();
+    llvm::StringRef name = funcOp.getSymName();
+    mlir::ArrayRef<mlir::Type> argumentTypes = funcOp.getArgumentTypes();
+    mlir::ArrayRef<mlir::Type> resultTypes = funcOp.getResultTypes();
+    std::optional<mlir::ArrayAttr> argAttrs = funcOp.getArgAttrs();
+
+    // Get portInfo used by the builder to create hw.module
+    mlir::SmallVector<circt::hw::PortInfo> inputsInfo, outputsInfo;
+    for (auto [idx, inputType] : llvm::enumerate(argumentTypes)) {
+        // get the name of input
+        std::string inputName;
+        if (argAttrs && idx < argAttrs->size()) {
+            mlir::Attribute argAttr = (*argAttrs)[idx];
+            mlir::DictionaryAttr dictAttr = llvm::dyn_cast_or_null<mlir::DictionaryAttr>(argAttr);
+            if (dictAttr) {
+                if (mlir::StringAttr nameAttr = dictAttr.getAs<mlir::StringAttr>("name")) { 
+                    inputName = nameAttr.getValue().str();
+                } else if (mlir::StringAttr nameAttr = dictAttr.getAs<mlir::StringAttr>("sym_name")) {
+                    inputName = nameAttr.getValue().str();
+                }
+            }
+        }
+
+        if (inputName.empty()) {
+            inputName = "in_" + std::to_string(idx);
+        }
+
+        circt::hw::PortInfo inputInfo;
+        inputInfo.name = builder.getStringAttr(inputName);
+        inputInfo.dir = circt::hw::ModulePort::Direction::Input;
+        inputInfo.type = inputType;
+        inputInfo.argNum = idx;
+
+        inputsInfo.push_back(inputInfo);
+    }
+
+    for (auto [idx, outputType] : llvm::enumerate(resultTypes)) {
+        std::string outputName = "out_" + std::to_string(idx);
+        circt::hw::PortInfo outputInfo;
+        outputInfo.name = builder.getStringAttr(outputName);
+        outputInfo.dir = circt::hw::ModulePort::Direction::Output;
+        outputInfo.type = outputType;
+        outputInfo.argNum = idx;
+
+        outputsInfo.push_back(outputInfo);
+    }
+
+    circt::hw::ModulePortInfo portInfo(inputsInfo, outputsInfo);
+    
+    // Create the hw.module operation
+    auto hwModule = circt::hw::HWModuleOp::create(
+        builder,                           // OpBuilder
+        loc,                              // Location
+        builder.getStringAttr(name),      // Module name
+        portInfo,                         // Port information
+        {},                               // Parameters (empty)
+        {},                               // Attributes (empty)
+        {},                               // Comment (empty)
+        false                              // shouldEnsureTerminator
+    );
+
+    return hwModule;
+}
+
+mlir::LogicalResult
+FuncToHWModulePass::copyOpFromFuncToHWModule(mlir::OpBuilder &builder, mlir::func::FuncOp funcOp, circt::hw::HWModuleOp hwModuleOp) {
+    // Get the bofy block of the hw.module
+    builder.setInsertionPoint(hwModuleOp.getBodyBlock(), hwModuleOp.getBodyBlock()->begin());
+
+    mlir::Block &funcOpBody = funcOp.getBody().front();
+    size_t moduleInPortNum = hwModuleOp.getNumInputPorts();
+    llvm::SmallVector<mlir::Value> moduleInPortValues;
+
+    // Get the values of the input ports of the hw.module
+    for (size_t i = 0; i < moduleInPortNum; ++i) {
+        moduleInPortValues.push_back(hwModuleOp.getArgumentForInput(i));
+    }
+
+    mlir::IRMapping valueMapping;
+    
+    // Ensure the number of arguments in the function body is equal to the number of input ports in the hw.module//
+    if (funcOpBody.getNumArguments() != moduleInPortNum) { 
+        llvm::errs() << "The number of arguments in the function body is not equal to the number of input ports in the hw.module\n";
+        return mlir::failure();
+    } 
+
+    for (auto [idx, funcArg] : llvm::enumerate(funcOpBody.getArguments())) {
+        mlir::BlockArgument hwInArg = hwModuleOp.getArgumentForInput(idx);
+        valueMapping.map(funcArg, hwInArg);
+    }
+
+    // Clone operations from func to hw.module. 
+    for (auto& op : llvm::make_early_inc_range(funcOpBody.getOperations())) {
+        if (auto returnOp = mlir::dyn_cast<mlir::func::ReturnOp>(op)) {
+            // Create hw.output operation for the return values.
+            llvm::SmallVector<mlir::Value> outputValues;
+            for (mlir::Value returnValue : returnOp.getOperands()) {
+                auto mappedValue = valueMapping.lookupOrNull(returnValue);
+                if (!mappedValue) { 
+                    llvm::errs() << "The return value " << returnValue << " is used before definition\n";
+                    return mlir::failure();
+                }
+
+                outputValues.push_back(mappedValue);
+            }
+
+            builder.create<circt::hw::OutputOp>(op.getLoc(), outputValues);
+            continue;
+        }
+
+        mlir::Operation* clonedOp = builder.clone(op, valueMapping);
+        if (!clonedOp) {
+          llvm::errs() << "Failed to clone operation " << op << "\n";
+          return mlir::failure();
+        }
+         
+        for (auto [originalResult, clonedResult] : 
+            llvm::zip(op.getResults(), clonedOp->getResults())) {
+            valueMapping.map(originalResult, clonedResult);
+        }
+    }
+
+    
+    return mlir::success();
+}
+
+mlir::LogicalResult FuncToHWModulePass::convertFuncToHWModule(mlir::func::FuncOp funcOp) {
+    mlir::OpBuilder builder(funcOp.getContext());
+    circt::hw::HWModuleOp hwModuleOp = buildHWModuleOPFromFuncOP(builder, funcOp);
+    
+    if (failed(copyOpFromFuncToHWModule(builder, funcOp, hwModuleOp))) {
+        return mlir::failure();
+    }
+    
+
+    return mlir::success();
+}
+
+mlir::LogicalResult FuncToHWModulePass::removeControlFlowFromFuncOp(mlir::func::FuncOp funcOp) {
+    CFRemover remover(funcOp.getBody());
+    return remover.run();
+}
+
+void FuncToHWModulePass::runOnOperation() {
+    for (auto op : llvm::make_early_inc_range(getOperation().getOps<mlir::func::FuncOp>())) {
+        if (mlir::failed(removeControlFlowFromFuncOp(op))) {
+            return signalPassFailure();
+        }
+
+        if (mlir::failed(convertFuncToHWModule(op))) {
+            return signalPassFailure();
+        }
+
+        op.erase();
+    }
+}

--- a/test/integration_tests/cases/execute_solver_with_btor2.sh
+++ b/test/integration_tests/cases/execute_solver_with_btor2.sh
@@ -12,10 +12,10 @@ solver="$1"
 name1="$2"
 name2="$3"
 out_dir="$4"
-input_files="$5"
+input_files=("${@:5}")
 
 # Construct Miter and Export to BTOR2
-equiv_miter --c1 "$name1" --c2 "$name2" "$input_files" --btor2 -o "$out_dir/miter.btor2"
+equiv_miter --c1 "$name1" --c2 "$name2" "${input_files[@]}" --btor2 -o "$out_dir/miter.btor2"
 
 # Solver runner
 equiv_fusion -p "solver_runner --solver "$solver" --inputfile "$out_dir/miter.btor2""

--- a/test/integration_tests/cases/execute_solver_with_cnf.sh
+++ b/test/integration_tests/cases/execute_solver_with_cnf.sh
@@ -12,10 +12,10 @@ solver="$1"
 name1="$2"
 name2="$3"
 out_dir="$4"
-input_files="$5"
+input_files=("${@:5}")
 
 # Construct Miter and Export to AIGER
-equiv_miter --c1 "$name1" --c2 "$name2" "$input_files" --aiger -o "$out_dir/miter.aiger"
+equiv_miter --c1 "$name1" --c2 "$name2" "${input_files[@]}" --aiger -o "$out_dir/miter.aiger"
 
 # Convert aiger to cnf
 aigtocnf "$out_dir/miter.aiger" "$out_dir/miter.cnf"

--- a/test/integration_tests/cases/execute_solver_with_smt2.sh
+++ b/test/integration_tests/cases/execute_solver_with_smt2.sh
@@ -12,10 +12,10 @@ solver="$1"
 name1="$2"
 name2="$3"
 out_dir="$4"
-input_files="$5"
+input_files=("${@:5}")
 
 # Construct Miter and Export SMT-LIB
-equiv_miter --c1 "$name1" --c2 "$name2" "$input_files" --smtlib -o "$out_dir/miter.smt"
+equiv_miter --c1 "$name1" --c2 "$name2" "${input_files[@]}" --smtlib -o "$out_dir/miter.smt"
 
 # Solver runner
 equiv_fusion -p "solver_runner --solver "$solver" --inputfile "$out_dir/miter.smt""

--- a/test/integration_tests/cases/lzc_c_to_dichotomy_run_bitwuzla_with_btor2/LZC.c
+++ b/test/integration_tests/cases/lzc_c_to_dichotomy_run_bitwuzla_with_btor2/LZC.c
@@ -1,0 +1,30 @@
+#include <stdint.h>
+#include <stdbool.h>
+
+/*
+void LZC(uint8_t data_in, uint8_t *lzc) {
+    uint8_t count = 0;
+    for (int j = 6; j >= 0; --j) { // 从bit6到bit0
+        if ((data_in >> j) & 1) break;
+        count++;
+    }
+    *lzc = count & 0x07;
+}
+*/
+
+uint8_t LZC(uint8_t data_in) {
+    uint8_t count = 0;
+    bool skip = false;
+    for (int i = 7; i >= 1; i--) {
+    	if (!skip) {
+	    if ((data_in >> i) & 1) {
+	        skip = true;
+	    } else {
+	        count++;
+	    }
+	}
+    }
+
+    return count;
+}
+

--- a/test/integration_tests/cases/lzc_c_to_dichotomy_run_bitwuzla_with_btor2/LZC.mlir
+++ b/test/integration_tests/cases/lzc_c_to_dichotomy_run_bitwuzla_with_btor2/LZC.mlir
@@ -1,0 +1,33 @@
+module {
+  func.func @LZC(%arg0: i8) -> i8 attributes {llvm.linkage = #llvm.linkage<external>} {
+    %c8 = arith.constant 8 : index
+    %c1_i8 = arith.constant 1 : i8
+    %c0_i32 = arith.constant 0 : i32
+    %c1_i32 = arith.constant 1 : i32
+    %c0_i8 = arith.constant 0 : i8
+    %0 = arith.extsi %arg0 : i8 to i32
+    %1:2 = affine.for %arg1 = 1 to 8 iter_args(%arg2 = %c0_i8, %arg3 = %c0_i8) -> (i8, i8) {
+      %2 = arith.subi %c8, %arg1 : index
+      %3 = arith.index_cast %2 : index to i32
+      %4 = arith.cmpi eq, %arg2, %c0_i8 : i8
+      %5 = arith.shrsi %0, %3 : i32
+      %6 = arith.andi %5, %c1_i32 : i32
+      %7 = arith.cmpi ne, %6, %c0_i32 : i32
+      %8 = arith.select %7, %c1_i8, %arg2 : i8
+      %9 = arith.select %4, %8, %arg2 : i8
+      %10 = scf.if %4 -> (i8) {
+        %11 = scf.if %7 -> (i8) {
+          scf.yield %arg3 : i8
+        } else {
+          %12 = arith.addi %arg3, %c1_i8 : i8
+          scf.yield %12 : i8
+        }
+        scf.yield %11 : i8
+      } else {
+        scf.yield %arg3 : i8
+      }
+      affine.yield %9, %10 : i8, i8
+    }
+    return %1#1 : i8
+  }
+}

--- a/test/integration_tests/cases/lzc_c_to_dichotomy_run_bitwuzla_with_btor2/lzc_c_to_dichotomy_run_bitwuzla_with_btor2.sh
+++ b/test/integration_tests/cases/lzc_c_to_dichotomy_run_bitwuzla_with_btor2/lzc_c_to_dichotomy_run_bitwuzla_with_btor2.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/bash
+
+set -euo pipefail
+
+CASE_DIR=$(dirname "$(realpath "$0")")
+OUTPUT_DIR=${CASE_LOG_PATH:-.}
+
+EXECUTE_SCRIPT="$CASE_DIR/../execute_solver_with_btor2.sh"
+
+equivfusion-hls "$CASE_DIR/LZC.mlir" -o "$OUTPUT_DIR/LZC_hls.mlir"
+
+#CHECK: unsat
+"$EXECUTE_SCRIPT" bitwuzla "LZC" "lzc7_dichotomy" "$OUTPUT_DIR" "$OUTPUT_DIR/LZC_hls.mlir" "$CASE_DIR/lzc_dichotomy.mlir"

--- a/test/integration_tests/cases/lzc_c_to_dichotomy_run_bitwuzla_with_btor2/lzc_dichotomy.mlir
+++ b/test/integration_tests/cases/lzc_c_to_dichotomy_run_bitwuzla_with_btor2/lzc_dichotomy.mlir
@@ -1,0 +1,26 @@
+module {
+  hw.module @lzc7_dichotomy(in %in_0 : i8, out out_0 : i8) {
+    %c-1_i3 = hw.constant -1 : i3
+    %c0_i2 = hw.constant 0 : i2
+    %c0_i4 = hw.constant 0 : i4
+    %c0_i5 = hw.constant 0 : i5
+    %0 = comb.concat %2, %7, %14 : i1, i1, i1
+    %1 = comb.extract %in_0 from 4 : (i8) -> i4
+    %2 = comb.icmp ne %1, %c0_i4 : i4
+    %3 = comb.extract %in_0 from 6 : (i8) -> i2
+    %4 = comb.icmp ne %3, %c0_i2 : i2
+    %5 = comb.extract %in_0 from 2 : (i8) -> i2
+    %6 = comb.icmp ne %5, %c0_i2 : i2
+    %7 = comb.mux %2, %4, %6 : i1
+    %8 = comb.extract %in_0 from 7 : (i8) -> i1
+    %9 = comb.extract %in_0 from 5 : (i8) -> i1
+    %10 = comb.mux %4, %8, %9 : i1
+    %11 = comb.extract %in_0 from 3 : (i8) -> i1
+    %12 = comb.extract %in_0 from 1 : (i8) -> i1
+    %13 = comb.mux %6, %11, %12 : i1
+    %14 = comb.mux %2, %10, %13 : i1
+    %15 = comb.xor %0, %c-1_i3 : i3
+    %16 = comb.concat %c0_i5, %15 : i5, i3
+    hw.output %16 : i8
+  }
+}

--- a/test/integration_tests/cases/lzc_c_to_dichotomy_run_bitwuzla_with_btor2/lzc_dichotomy.v
+++ b/test/integration_tests/cases/lzc_c_to_dichotomy_run_bitwuzla_with_btor2/lzc_dichotomy.v
@@ -1,0 +1,17 @@
+module lzc7_dichotomy
+(
+    input   [7:0]   in_0,
+        
+    output  [7:0]   out_0                                
+);
+
+wire [2:0] leading_one ;
+
+assign leading_one[2] = |in_0[7:4] ;
+assign leading_one[1] = (|in_0[7:4]) ? (|in_0[7:6]) : (|in_0[3:2]) ;
+assign leading_one[0] = (|in_0[7:4]) ? (|in_0[7:6]) ? in_0[7] : in_0[5] : (|in_0[3:2]) ? in_0[3] : in_0[1] ;
+//(|in_0[6:3]) ? (in_0[6] | (~in_0[5] & in_0[4])) : (in_0[2] | (~in_0[1] & in_0[0])) ;
+
+assign out_0 = {5'h0, ~leading_one};
+
+endmodule

--- a/test/integration_tests/cases/lzc_c_to_dichotomy_run_bitwuzla_with_smt2/LZC.c
+++ b/test/integration_tests/cases/lzc_c_to_dichotomy_run_bitwuzla_with_smt2/LZC.c
@@ -1,0 +1,30 @@
+#include <stdint.h>
+#include <stdbool.h>
+
+/*
+void LZC(uint8_t data_in, uint8_t *lzc) {
+    uint8_t count = 0;
+    for (int j = 6; j >= 0; --j) { // 从bit6到bit0
+        if ((data_in >> j) & 1) break;
+        count++;
+    }
+    *lzc = count & 0x07;
+}
+*/
+
+uint8_t LZC(uint8_t data_in) {
+    uint8_t count = 0;
+    bool skip = false;
+    for (int i = 7; i >= 1; i--) {
+    	if (!skip) {
+	    if ((data_in >> i) & 1) {
+	        skip = true;
+	    } else {
+	        count++;
+	    }
+	}
+    }
+
+    return count;
+}
+

--- a/test/integration_tests/cases/lzc_c_to_dichotomy_run_bitwuzla_with_smt2/LZC.mlir
+++ b/test/integration_tests/cases/lzc_c_to_dichotomy_run_bitwuzla_with_smt2/LZC.mlir
@@ -1,0 +1,33 @@
+module {
+  func.func @LZC(%arg0: i8) -> i8 attributes {llvm.linkage = #llvm.linkage<external>} {
+    %c8 = arith.constant 8 : index
+    %c1_i8 = arith.constant 1 : i8
+    %c0_i32 = arith.constant 0 : i32
+    %c1_i32 = arith.constant 1 : i32
+    %c0_i8 = arith.constant 0 : i8
+    %0 = arith.extsi %arg0 : i8 to i32
+    %1:2 = affine.for %arg1 = 1 to 8 iter_args(%arg2 = %c0_i8, %arg3 = %c0_i8) -> (i8, i8) {
+      %2 = arith.subi %c8, %arg1 : index
+      %3 = arith.index_cast %2 : index to i32
+      %4 = arith.cmpi eq, %arg2, %c0_i8 : i8
+      %5 = arith.shrsi %0, %3 : i32
+      %6 = arith.andi %5, %c1_i32 : i32
+      %7 = arith.cmpi ne, %6, %c0_i32 : i32
+      %8 = arith.select %7, %c1_i8, %arg2 : i8
+      %9 = arith.select %4, %8, %arg2 : i8
+      %10 = scf.if %4 -> (i8) {
+        %11 = scf.if %7 -> (i8) {
+          scf.yield %arg3 : i8
+        } else {
+          %12 = arith.addi %arg3, %c1_i8 : i8
+          scf.yield %12 : i8
+        }
+        scf.yield %11 : i8
+      } else {
+        scf.yield %arg3 : i8
+      }
+      affine.yield %9, %10 : i8, i8
+    }
+    return %1#1 : i8
+  }
+}

--- a/test/integration_tests/cases/lzc_c_to_dichotomy_run_bitwuzla_with_smt2/lzc_c_to_dichotomy_run_bitwuzla_with_smt2.sh
+++ b/test/integration_tests/cases/lzc_c_to_dichotomy_run_bitwuzla_with_smt2/lzc_c_to_dichotomy_run_bitwuzla_with_smt2.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/bash
+
+set -euo pipefail
+
+CASE_DIR=$(dirname "$(realpath "$0")")
+OUTPUT_DIR=${CASE_LOG_PATH:-.}
+
+EXECUTE_SCRIPT="$CASE_DIR/../execute_solver_with_smt2.sh"
+
+equivfusion-hls "$CASE_DIR/LZC.mlir" -o "$OUTPUT_DIR/LZC_hls.mlir"
+
+#CHECK: unsat
+"$EXECUTE_SCRIPT" bitwuzla "LZC" "lzc7_dichotomy" "$OUTPUT_DIR" "$OUTPUT_DIR/LZC_hls.mlir" "$CASE_DIR/lzc_dichotomy.mlir"

--- a/test/integration_tests/cases/lzc_c_to_dichotomy_run_bitwuzla_with_smt2/lzc_dichotomy.mlir
+++ b/test/integration_tests/cases/lzc_c_to_dichotomy_run_bitwuzla_with_smt2/lzc_dichotomy.mlir
@@ -1,0 +1,26 @@
+module {
+  hw.module @lzc7_dichotomy(in %in_0 : i8, out out_0 : i8) {
+    %c-1_i3 = hw.constant -1 : i3
+    %c0_i2 = hw.constant 0 : i2
+    %c0_i4 = hw.constant 0 : i4
+    %c0_i5 = hw.constant 0 : i5
+    %0 = comb.concat %2, %7, %14 : i1, i1, i1
+    %1 = comb.extract %in_0 from 4 : (i8) -> i4
+    %2 = comb.icmp ne %1, %c0_i4 : i4
+    %3 = comb.extract %in_0 from 6 : (i8) -> i2
+    %4 = comb.icmp ne %3, %c0_i2 : i2
+    %5 = comb.extract %in_0 from 2 : (i8) -> i2
+    %6 = comb.icmp ne %5, %c0_i2 : i2
+    %7 = comb.mux %2, %4, %6 : i1
+    %8 = comb.extract %in_0 from 7 : (i8) -> i1
+    %9 = comb.extract %in_0 from 5 : (i8) -> i1
+    %10 = comb.mux %4, %8, %9 : i1
+    %11 = comb.extract %in_0 from 3 : (i8) -> i1
+    %12 = comb.extract %in_0 from 1 : (i8) -> i1
+    %13 = comb.mux %6, %11, %12 : i1
+    %14 = comb.mux %2, %10, %13 : i1
+    %15 = comb.xor %0, %c-1_i3 : i3
+    %16 = comb.concat %c0_i5, %15 : i5, i3
+    hw.output %16 : i8
+  }
+}

--- a/test/integration_tests/cases/lzc_c_to_dichotomy_run_bitwuzla_with_smt2/lzc_dichotomy.v
+++ b/test/integration_tests/cases/lzc_c_to_dichotomy_run_bitwuzla_with_smt2/lzc_dichotomy.v
@@ -1,0 +1,17 @@
+module lzc7_dichotomy
+(
+    input   [7:0]   in_0,
+        
+    output  [7:0]   out_0                                
+);
+
+wire [2:0] leading_one ;
+
+assign leading_one[2] = |in_0[7:4] ;
+assign leading_one[1] = (|in_0[7:4]) ? (|in_0[7:6]) : (|in_0[3:2]) ;
+assign leading_one[0] = (|in_0[7:4]) ? (|in_0[7:6]) ? in_0[7] : in_0[5] : (|in_0[3:2]) ? in_0[3] : in_0[1] ;
+//(|in_0[6:3]) ? (in_0[6] | (~in_0[5] & in_0[4])) : (in_0[2] | (~in_0[1] & in_0[0])) ;
+
+assign out_0 = {5'h0, ~leading_one};
+
+endmodule

--- a/test/integration_tests/cases/lzc_c_to_dichotomy_run_btormc_with_btor2/LZC.c
+++ b/test/integration_tests/cases/lzc_c_to_dichotomy_run_btormc_with_btor2/LZC.c
@@ -1,0 +1,30 @@
+#include <stdint.h>
+#include <stdbool.h>
+
+/*
+void LZC(uint8_t data_in, uint8_t *lzc) {
+    uint8_t count = 0;
+    for (int j = 6; j >= 0; --j) { // 从bit6到bit0
+        if ((data_in >> j) & 1) break;
+        count++;
+    }
+    *lzc = count & 0x07;
+}
+*/
+
+uint8_t LZC(uint8_t data_in) {
+    uint8_t count = 0;
+    bool skip = false;
+    for (int i = 7; i >= 1; i--) {
+    	if (!skip) {
+	    if ((data_in >> i) & 1) {
+	        skip = true;
+	    } else {
+	        count++;
+	    }
+	}
+    }
+
+    return count;
+}
+

--- a/test/integration_tests/cases/lzc_c_to_dichotomy_run_btormc_with_btor2/LZC.mlir
+++ b/test/integration_tests/cases/lzc_c_to_dichotomy_run_btormc_with_btor2/LZC.mlir
@@ -1,0 +1,33 @@
+module {
+  func.func @LZC(%arg0: i8) -> i8 attributes {llvm.linkage = #llvm.linkage<external>} {
+    %c8 = arith.constant 8 : index
+    %c1_i8 = arith.constant 1 : i8
+    %c0_i32 = arith.constant 0 : i32
+    %c1_i32 = arith.constant 1 : i32
+    %c0_i8 = arith.constant 0 : i8
+    %0 = arith.extsi %arg0 : i8 to i32
+    %1:2 = affine.for %arg1 = 1 to 8 iter_args(%arg2 = %c0_i8, %arg3 = %c0_i8) -> (i8, i8) {
+      %2 = arith.subi %c8, %arg1 : index
+      %3 = arith.index_cast %2 : index to i32
+      %4 = arith.cmpi eq, %arg2, %c0_i8 : i8
+      %5 = arith.shrsi %0, %3 : i32
+      %6 = arith.andi %5, %c1_i32 : i32
+      %7 = arith.cmpi ne, %6, %c0_i32 : i32
+      %8 = arith.select %7, %c1_i8, %arg2 : i8
+      %9 = arith.select %4, %8, %arg2 : i8
+      %10 = scf.if %4 -> (i8) {
+        %11 = scf.if %7 -> (i8) {
+          scf.yield %arg3 : i8
+        } else {
+          %12 = arith.addi %arg3, %c1_i8 : i8
+          scf.yield %12 : i8
+        }
+        scf.yield %11 : i8
+      } else {
+        scf.yield %arg3 : i8
+      }
+      affine.yield %9, %10 : i8, i8
+    }
+    return %1#1 : i8
+  }
+}

--- a/test/integration_tests/cases/lzc_c_to_dichotomy_run_btormc_with_btor2/lzc_c_to_dichotomy_run_btormc_with_btor2.sh
+++ b/test/integration_tests/cases/lzc_c_to_dichotomy_run_btormc_with_btor2/lzc_c_to_dichotomy_run_btormc_with_btor2.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/bash
+
+set -euo pipefail
+
+CASE_DIR=$(dirname "$(realpath "$0")")
+OUTPUT_DIR=${CASE_LOG_PATH:-.}
+
+EXECUTE_SCRIPT="$CASE_DIR/../execute_solver_with_btor2.sh"
+
+equivfusion-hls "$CASE_DIR/LZC.mlir" -o "$OUTPUT_DIR/LZC_hls.mlir"
+
+#CHECK: unsat
+"$EXECUTE_SCRIPT" btormc "LZC" "lzc7_dichotomy" "$OUTPUT_DIR" "$OUTPUT_DIR/LZC_hls.mlir" "$CASE_DIR/lzc_dichotomy.mlir"
+

--- a/test/integration_tests/cases/lzc_c_to_dichotomy_run_btormc_with_btor2/lzc_dichotomy.mlir
+++ b/test/integration_tests/cases/lzc_c_to_dichotomy_run_btormc_with_btor2/lzc_dichotomy.mlir
@@ -1,0 +1,26 @@
+module {
+  hw.module @lzc7_dichotomy(in %in_0 : i8, out out_0 : i8) {
+    %c-1_i3 = hw.constant -1 : i3
+    %c0_i2 = hw.constant 0 : i2
+    %c0_i4 = hw.constant 0 : i4
+    %c0_i5 = hw.constant 0 : i5
+    %0 = comb.concat %2, %7, %14 : i1, i1, i1
+    %1 = comb.extract %in_0 from 4 : (i8) -> i4
+    %2 = comb.icmp ne %1, %c0_i4 : i4
+    %3 = comb.extract %in_0 from 6 : (i8) -> i2
+    %4 = comb.icmp ne %3, %c0_i2 : i2
+    %5 = comb.extract %in_0 from 2 : (i8) -> i2
+    %6 = comb.icmp ne %5, %c0_i2 : i2
+    %7 = comb.mux %2, %4, %6 : i1
+    %8 = comb.extract %in_0 from 7 : (i8) -> i1
+    %9 = comb.extract %in_0 from 5 : (i8) -> i1
+    %10 = comb.mux %4, %8, %9 : i1
+    %11 = comb.extract %in_0 from 3 : (i8) -> i1
+    %12 = comb.extract %in_0 from 1 : (i8) -> i1
+    %13 = comb.mux %6, %11, %12 : i1
+    %14 = comb.mux %2, %10, %13 : i1
+    %15 = comb.xor %0, %c-1_i3 : i3
+    %16 = comb.concat %c0_i5, %15 : i5, i3
+    hw.output %16 : i8
+  }
+}

--- a/test/integration_tests/cases/lzc_c_to_dichotomy_run_btormc_with_btor2/lzc_dichotomy.v
+++ b/test/integration_tests/cases/lzc_c_to_dichotomy_run_btormc_with_btor2/lzc_dichotomy.v
@@ -1,0 +1,17 @@
+module lzc7_dichotomy
+(
+    input   [7:0]   in_0,
+        
+    output  [7:0]   out_0                                
+);
+
+wire [2:0] leading_one ;
+
+assign leading_one[2] = |in_0[7:4] ;
+assign leading_one[1] = (|in_0[7:4]) ? (|in_0[7:6]) : (|in_0[3:2]) ;
+assign leading_one[0] = (|in_0[7:4]) ? (|in_0[7:6]) ? in_0[7] : in_0[5] : (|in_0[3:2]) ? in_0[3] : in_0[1] ;
+//(|in_0[6:3]) ? (in_0[6] | (~in_0[5] & in_0[4])) : (in_0[2] | (~in_0[1] & in_0[0])) ;
+
+assign out_0 = {5'h0, ~leading_one};
+
+endmodule

--- a/test/integration_tests/cases/lzc_c_to_dichotomy_run_kissat/LZC.c
+++ b/test/integration_tests/cases/lzc_c_to_dichotomy_run_kissat/LZC.c
@@ -1,0 +1,30 @@
+#include <stdint.h>
+#include <stdbool.h>
+
+/*
+void LZC(uint8_t data_in, uint8_t *lzc) {
+    uint8_t count = 0;
+    for (int j = 6; j >= 0; --j) { // 从bit6到bit0
+        if ((data_in >> j) & 1) break;
+        count++;
+    }
+    *lzc = count & 0x07;
+}
+*/
+
+uint8_t LZC(uint8_t data_in) {
+    uint8_t count = 0;
+    bool skip = false;
+    for (int i = 7; i >= 1; i--) {
+    	if (!skip) {
+	    if ((data_in >> i) & 1) {
+	        skip = true;
+	    } else {
+	        count++;
+	    }
+	}
+    }
+
+    return count;
+}
+

--- a/test/integration_tests/cases/lzc_c_to_dichotomy_run_kissat/LZC.mlir
+++ b/test/integration_tests/cases/lzc_c_to_dichotomy_run_kissat/LZC.mlir
@@ -1,0 +1,33 @@
+module {
+  func.func @LZC(%arg0: i8) -> i8 attributes {llvm.linkage = #llvm.linkage<external>} {
+    %c8 = arith.constant 8 : index
+    %c1_i8 = arith.constant 1 : i8
+    %c0_i32 = arith.constant 0 : i32
+    %c1_i32 = arith.constant 1 : i32
+    %c0_i8 = arith.constant 0 : i8
+    %0 = arith.extsi %arg0 : i8 to i32
+    %1:2 = affine.for %arg1 = 1 to 8 iter_args(%arg2 = %c0_i8, %arg3 = %c0_i8) -> (i8, i8) {
+      %2 = arith.subi %c8, %arg1 : index
+      %3 = arith.index_cast %2 : index to i32
+      %4 = arith.cmpi eq, %arg2, %c0_i8 : i8
+      %5 = arith.shrsi %0, %3 : i32
+      %6 = arith.andi %5, %c1_i32 : i32
+      %7 = arith.cmpi ne, %6, %c0_i32 : i32
+      %8 = arith.select %7, %c1_i8, %arg2 : i8
+      %9 = arith.select %4, %8, %arg2 : i8
+      %10 = scf.if %4 -> (i8) {
+        %11 = scf.if %7 -> (i8) {
+          scf.yield %arg3 : i8
+        } else {
+          %12 = arith.addi %arg3, %c1_i8 : i8
+          scf.yield %12 : i8
+        }
+        scf.yield %11 : i8
+      } else {
+        scf.yield %arg3 : i8
+      }
+      affine.yield %9, %10 : i8, i8
+    }
+    return %1#1 : i8
+  }
+}

--- a/test/integration_tests/cases/lzc_c_to_dichotomy_run_kissat/lzc_c_to_dichotomy_run_kissat.sh
+++ b/test/integration_tests/cases/lzc_c_to_dichotomy_run_kissat/lzc_c_to_dichotomy_run_kissat.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/bash
+
+set -euo pipefail
+
+CASE_DIR=$(dirname "$(realpath "$0")")
+OUTPUT_DIR=${CASE_LOG_PATH:-.}
+
+EXECUTE_SCRIPT="$CASE_DIR/../execute_solver_with_cnf.sh"
+
+equivfusion-hls "$CASE_DIR/LZC.mlir" -o "$OUTPUT_DIR/LZC_hls.mlir"
+
+#CHECK: UNSATISFIABLE
+"$EXECUTE_SCRIPT" kissat "LZC" "lzc7_dichotomy" "$OUTPUT_DIR" "$OUTPUT_DIR/LZC_hls.mlir" "$CASE_DIR/lzc_dichotomy.mlir"
+

--- a/test/integration_tests/cases/lzc_c_to_dichotomy_run_kissat/lzc_dichotomy.mlir
+++ b/test/integration_tests/cases/lzc_c_to_dichotomy_run_kissat/lzc_dichotomy.mlir
@@ -1,0 +1,26 @@
+module {
+  hw.module @lzc7_dichotomy(in %in_0 : i8, out out_0 : i8) {
+    %c-1_i3 = hw.constant -1 : i3
+    %c0_i2 = hw.constant 0 : i2
+    %c0_i4 = hw.constant 0 : i4
+    %c0_i5 = hw.constant 0 : i5
+    %0 = comb.concat %2, %7, %14 : i1, i1, i1
+    %1 = comb.extract %in_0 from 4 : (i8) -> i4
+    %2 = comb.icmp ne %1, %c0_i4 : i4
+    %3 = comb.extract %in_0 from 6 : (i8) -> i2
+    %4 = comb.icmp ne %3, %c0_i2 : i2
+    %5 = comb.extract %in_0 from 2 : (i8) -> i2
+    %6 = comb.icmp ne %5, %c0_i2 : i2
+    %7 = comb.mux %2, %4, %6 : i1
+    %8 = comb.extract %in_0 from 7 : (i8) -> i1
+    %9 = comb.extract %in_0 from 5 : (i8) -> i1
+    %10 = comb.mux %4, %8, %9 : i1
+    %11 = comb.extract %in_0 from 3 : (i8) -> i1
+    %12 = comb.extract %in_0 from 1 : (i8) -> i1
+    %13 = comb.mux %6, %11, %12 : i1
+    %14 = comb.mux %2, %10, %13 : i1
+    %15 = comb.xor %0, %c-1_i3 : i3
+    %16 = comb.concat %c0_i5, %15 : i5, i3
+    hw.output %16 : i8
+  }
+}

--- a/test/integration_tests/cases/lzc_c_to_dichotomy_run_kissat/lzc_dichotomy.v
+++ b/test/integration_tests/cases/lzc_c_to_dichotomy_run_kissat/lzc_dichotomy.v
@@ -1,0 +1,17 @@
+module lzc7_dichotomy
+(
+    input   [7:0]   in_0,
+        
+    output  [7:0]   out_0                                
+);
+
+wire [2:0] leading_one ;
+
+assign leading_one[2] = |in_0[7:4] ;
+assign leading_one[1] = (|in_0[7:4]) ? (|in_0[7:6]) : (|in_0[3:2]) ;
+assign leading_one[0] = (|in_0[7:4]) ? (|in_0[7:6]) ? in_0[7] : in_0[5] : (|in_0[3:2]) ? in_0[3] : in_0[1] ;
+//(|in_0[6:3]) ? (in_0[6] | (~in_0[5] & in_0[4])) : (in_0[2] | (~in_0[1] & in_0[0])) ;
+
+assign out_0 = {5'h0, ~leading_one};
+
+endmodule

--- a/test/integration_tests/cases/lzc_c_to_dichotomy_run_z3_with_smt2/LZC.c
+++ b/test/integration_tests/cases/lzc_c_to_dichotomy_run_z3_with_smt2/LZC.c
@@ -1,0 +1,30 @@
+#include <stdint.h>
+#include <stdbool.h>
+
+/*
+void LZC(uint8_t data_in, uint8_t *lzc) {
+    uint8_t count = 0;
+    for (int j = 6; j >= 0; --j) { // 从bit6到bit0
+        if ((data_in >> j) & 1) break;
+        count++;
+    }
+    *lzc = count & 0x07;
+}
+*/
+
+uint8_t LZC(uint8_t data_in) {
+    uint8_t count = 0;
+    bool skip = false;
+    for (int i = 7; i >= 1; i--) {
+    	if (!skip) {
+	    if ((data_in >> i) & 1) {
+	        skip = true;
+	    } else {
+	        count++;
+	    }
+	}
+    }
+
+    return count;
+}
+

--- a/test/integration_tests/cases/lzc_c_to_dichotomy_run_z3_with_smt2/LZC.mlir
+++ b/test/integration_tests/cases/lzc_c_to_dichotomy_run_z3_with_smt2/LZC.mlir
@@ -1,0 +1,33 @@
+module {
+  func.func @LZC(%arg0: i8) -> i8 attributes {llvm.linkage = #llvm.linkage<external>} {
+    %c8 = arith.constant 8 : index
+    %c1_i8 = arith.constant 1 : i8
+    %c0_i32 = arith.constant 0 : i32
+    %c1_i32 = arith.constant 1 : i32
+    %c0_i8 = arith.constant 0 : i8
+    %0 = arith.extsi %arg0 : i8 to i32
+    %1:2 = affine.for %arg1 = 1 to 8 iter_args(%arg2 = %c0_i8, %arg3 = %c0_i8) -> (i8, i8) {
+      %2 = arith.subi %c8, %arg1 : index
+      %3 = arith.index_cast %2 : index to i32
+      %4 = arith.cmpi eq, %arg2, %c0_i8 : i8
+      %5 = arith.shrsi %0, %3 : i32
+      %6 = arith.andi %5, %c1_i32 : i32
+      %7 = arith.cmpi ne, %6, %c0_i32 : i32
+      %8 = arith.select %7, %c1_i8, %arg2 : i8
+      %9 = arith.select %4, %8, %arg2 : i8
+      %10 = scf.if %4 -> (i8) {
+        %11 = scf.if %7 -> (i8) {
+          scf.yield %arg3 : i8
+        } else {
+          %12 = arith.addi %arg3, %c1_i8 : i8
+          scf.yield %12 : i8
+        }
+        scf.yield %11 : i8
+      } else {
+        scf.yield %arg3 : i8
+      }
+      affine.yield %9, %10 : i8, i8
+    }
+    return %1#1 : i8
+  }
+}

--- a/test/integration_tests/cases/lzc_c_to_dichotomy_run_z3_with_smt2/lzc_c_to_dichotomy_run_z3_with_smt2.sh
+++ b/test/integration_tests/cases/lzc_c_to_dichotomy_run_z3_with_smt2/lzc_c_to_dichotomy_run_z3_with_smt2.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/bash
+
+set -euo pipefail
+
+CASE_DIR=$(dirname "$(realpath "$0")")
+OUTPUT_DIR=${CASE_LOG_PATH:-.}
+
+EXECUTE_SCRIPT="$CASE_DIR/../execute_solver_with_smt2.sh"
+
+equivfusion-hls "$CASE_DIR/LZC.mlir" -o "$OUTPUT_DIR/LZC_hls.mlir"
+
+#CHECK: unsat
+"$EXECUTE_SCRIPT" z3 "LZC" "lzc7_dichotomy" "$OUTPUT_DIR" "$OUTPUT_DIR/LZC_hls.mlir" "$CASE_DIR/lzc_dichotomy.mlir"
+

--- a/test/integration_tests/cases/lzc_c_to_dichotomy_run_z3_with_smt2/lzc_dichotomy.mlir
+++ b/test/integration_tests/cases/lzc_c_to_dichotomy_run_z3_with_smt2/lzc_dichotomy.mlir
@@ -1,0 +1,26 @@
+module {
+  hw.module @lzc7_dichotomy(in %in_0 : i8, out out_0 : i8) {
+    %c-1_i3 = hw.constant -1 : i3
+    %c0_i2 = hw.constant 0 : i2
+    %c0_i4 = hw.constant 0 : i4
+    %c0_i5 = hw.constant 0 : i5
+    %0 = comb.concat %2, %7, %14 : i1, i1, i1
+    %1 = comb.extract %in_0 from 4 : (i8) -> i4
+    %2 = comb.icmp ne %1, %c0_i4 : i4
+    %3 = comb.extract %in_0 from 6 : (i8) -> i2
+    %4 = comb.icmp ne %3, %c0_i2 : i2
+    %5 = comb.extract %in_0 from 2 : (i8) -> i2
+    %6 = comb.icmp ne %5, %c0_i2 : i2
+    %7 = comb.mux %2, %4, %6 : i1
+    %8 = comb.extract %in_0 from 7 : (i8) -> i1
+    %9 = comb.extract %in_0 from 5 : (i8) -> i1
+    %10 = comb.mux %4, %8, %9 : i1
+    %11 = comb.extract %in_0 from 3 : (i8) -> i1
+    %12 = comb.extract %in_0 from 1 : (i8) -> i1
+    %13 = comb.mux %6, %11, %12 : i1
+    %14 = comb.mux %2, %10, %13 : i1
+    %15 = comb.xor %0, %c-1_i3 : i3
+    %16 = comb.concat %c0_i5, %15 : i5, i3
+    hw.output %16 : i8
+  }
+}

--- a/test/integration_tests/cases/lzc_c_to_dichotomy_run_z3_with_smt2/lzc_dichotomy.v
+++ b/test/integration_tests/cases/lzc_c_to_dichotomy_run_z3_with_smt2/lzc_dichotomy.v
@@ -1,0 +1,17 @@
+module lzc7_dichotomy
+(
+    input   [7:0]   in_0,
+        
+    output  [7:0]   out_0                                
+);
+
+wire [2:0] leading_one ;
+
+assign leading_one[2] = |in_0[7:4] ;
+assign leading_one[1] = (|in_0[7:4]) ? (|in_0[7:6]) : (|in_0[3:2]) ;
+assign leading_one[0] = (|in_0[7:4]) ? (|in_0[7:6]) ? in_0[7] : in_0[5] : (|in_0[3:2]) ? in_0[3] : in_0[1] ;
+//(|in_0[6:3]) ? (in_0[6] | (~in_0[5] & in_0[4])) : (in_0[2] | (~in_0[1] & in_0[0])) ;
+
+assign out_0 = {5'h0, ~leading_one};
+
+endmodule

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -1,3 +1,4 @@
 add_subdirectory(circt-lec)
 add_subdirectory(equiv_miter)
 
+add_subdirectory(equivfusion-hls)

--- a/tools/equivfusion-hls/CMakeLists.txt
+++ b/tools/equivfusion-hls/CMakeLists.txt
@@ -1,0 +1,32 @@
+add_llvm_executable(equivfusion-hls equivfusion-hls.cpp)
+
+set(LLVM_LINK_COMPONENTS Support)
+
+target_link_libraries(equivfusion-hls 
+  PRIVATE
+
+  CIRCTHW
+  CIRCTHWTransforms
+  CIRCTSeq
+  CIRCTSeqTransforms
+  CIRCTTransforms
+
+  MLIRIR
+  MLIRLLVMDialect
+  MLIRMemRefDialect
+  MLIROptLib
+  MLIRParser
+  MLIRControlFlowDialect
+  MLIRSupport
+  MLIRTransforms
+  MLIRSCFToControlFlow
+  MLIRAffineToStandard
+
+  FuncToHWModule
+  log
+)
+
+target_include_directories(equivfusion-hls PUBLIC ${INCLUDE_DIRS})
+
+llvm_update_compile_flags(equivfusion-hls)
+mlir_check_all_link_libraries(equivfusion-hls)

--- a/tools/equivfusion-hls/equivfusion-hls.cpp
+++ b/tools/equivfusion-hls/equivfusion-hls.cpp
@@ -1,0 +1,202 @@
+#include "infrastructure/log/log.h"
+
+#include "mlir/Dialect/Affine/IR/AffineOps.h"
+#include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Dialect/Affine/Passes.h"
+#include "mlir/Dialect/ControlFlow/IR/ControlFlowOps.h"
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/Dialect/MemRef/IR/MemRef.h"
+#include "mlir/Dialect/SCF/IR/SCF.h"
+#include "mlir/IR/AsmState.h"
+#include "mlir/IR/BuiltinOps.h"
+#include "mlir/Parser/Parser.h"
+#include "mlir/Pass/Pass.h"
+#include "mlir/Pass/PassInstrumentation.h"
+#include "mlir/Pass/PassManager.h"
+#include "mlir/Support/FileUtilities.h"
+#include "mlir/Support/Timing.h"
+#include "mlir/Support/ToolUtilities.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+#include "mlir/Transforms/Passes.h"
+#include "mlir/Conversion/Passes.h"
+
+#include "llvm/Support/CommandLine.h"
+#include "llvm/Support/InitLLVM.h"
+#include "llvm/Support/PrettyStackTrace.h"
+#include "llvm/Support/SourceMgr.h"
+#include "llvm/Support/ToolOutputFile.h"
+#include "llvm/Support/LogicalResult.h"
+#include "llvm/Support/FileUtilities.h"
+
+#include "circt/Conversion/Passes.h"
+#include "circt/Dialect/Seq/SeqDialect.h"
+#include "circt/Dialect/Seq/SeqPasses.h"
+#include "circt/Transforms/Passes.h"
+
+#include "circt-passes/FuncToHWModule/Passes.h"
+
+namespace cl = llvm::cl;
+
+
+static cl::OptionCategory mainCategory("equivfusion-hls Options");
+
+static cl::opt<std::string> inputFilename(cl::Positional, cl::desc("Input filename"), 
+    cl::init("-"), cl::cat(mainCategory)
+);
+
+static cl::opt<std::string> outputFilename("o", cl::desc("Output filename"),
+   cl::value_desc("filename"),
+   cl::init("-"),
+   cl::cat(mainCategory));
+
+static llvm::LogicalResult 
+processInput(mlir::MLIRContext &context, mlir::TimingScope &ts, 
+             std::unique_ptr<llvm::MemoryBuffer> input, 
+             std::optional<std::unique_ptr<llvm::ToolOutputFile>> &outputFile) {
+    
+    context.allowUnregisteredDialects();
+
+    // Setup of diagnostic handling.
+    llvm::SourceMgr sourceMgr;
+    sourceMgr.AddNewSourceBuffer(std::move(input), llvm::SMLoc());
+    mlir::SourceMgrDiagnosticHandler sourceMgrHandle(sourceMgr, &context);
+    context.printOpOnDiagnostic(false);
+
+    mlir::OwningOpRef<mlir::ModuleOp> module;
+    auto parserTS = ts.nest("HLS Parse");
+    module = mlir::parseSourceFile<mlir::ModuleOp>(sourceMgr, &context);
+
+    if (!module) {
+        return llvm::failure();
+    }
+
+    // Apply any pass manager command line options.
+    mlir::PassManager pm(&context);
+    pm.enableTiming(ts);
+    if (llvm::failed(mlir::applyPassManagerCLOptions(pm))) {
+        return llvm::failure();
+    }
+
+    // Unroll affine loops.
+    pm.addPass(mlir::createCanonicalizerPass());
+    pm.addNestedPass<mlir::func::FuncOp>(mlir::affine::createLoopUnrollPass(-1, false, true, nullptr));
+    
+    // Lower affine to a conbination of Arith and
+    pm.addPass(mlir::createCanonicalizerPass());
+    pm.addPass(mlir::createLowerAffinePass());
+
+    // Lower Scf to ControlFlow dialect.
+    pm.addPass(mlir::createCanonicalizerPass());
+    pm.addPass(mlir::createSCFToControlFlowPass());
+
+    // Convert Arith to Comb
+    pm.addPass(mlir::createCanonicalizerPass());
+    pm.addPass(circt::createMapArithToCombPass());
+
+    //Convert Func to Module
+    pm.addPass(mlir::createCanonicalizerPass());
+    pm.addPass(circt::createFuncToHWModule());
+    
+    pm.addPass(mlir::createCanonicalizerPass());
+    
+    if (mlir::failed(pm.run(module.get()))) { 
+        return llvm::failure();
+    }
+
+    module.get()->print((*outputFile)->os());
+
+    // We intentionally "leak" the Module into the MLIRContext instead of
+    // deallocating it.  There is no need to deallocate it right before process
+    // exit.
+    (void)module.release();
+    return llvm::success();
+}
+
+
+static llvm::LogicalResult executeHls(mlir::MLIRContext &context) {
+    // Create the timing manager we use to sample execution times.
+    mlir::DefaultTimingManager tm;
+    mlir::applyDefaultTimingManagerCLOptions(tm);
+    auto ts = tm.getRootScope();
+
+    // Set up the input file.
+    std::string errorMessage;
+    auto input = mlir::openInputFile(inputFilename, &errorMessage);
+    if (!input) {
+        llvm::errs() << errorMessage << "\n";
+        return llvm::failure();
+    }
+
+    std::optional<std::unique_ptr<llvm::ToolOutputFile>> outputFile;
+    outputFile.emplace(mlir::openOutputFile(outputFilename, &errorMessage));
+    if (!*outputFile) {
+        llvm::errs() << errorMessage << "\n";
+        return llvm::failure();
+    }
+
+    // Proecss the input
+    if (llvm::failed(processInput(context, ts, std::move(input), outputFile))) {
+        return llvm::failure();
+    }
+
+    // If the result succeeded and we're emitting a file, close it.
+    if (outputFile.has_value()) {
+        (*outputFile)->keep();
+    }
+
+    return llvm::success();
+}
+
+
+/// The entry point for the `equivfusion-hls` tool:
+/// configures and parses the command-line options,
+/// registers all dialects within a MLIR context,
+/// and calls the `executeHLS` function to do the actual work.
+int main(int argc, char **argv) {
+    llvm::InitLLVM y(argc, argv);
+
+    // Hide default LLVM options, other than for this tool.
+    // MLIR options are added below.
+    cl::HideUnrelatedOptions(mainCategory);
+
+    // Register any pass manager command line options.
+    mlir::registerMLIRContextCLOptions();
+    mlir::registerPassManagerCLOptions();
+    mlir::registerDefaultTimingManagerCLOptions();
+    mlir::registerAsmPrinterCLOptions();
+
+    // Parse the command-line options provided by the user.
+    cl::ParseCommandLineOptions(argc, argv, "equivfusion-hls");
+    
+    // Register the supported CIRCT dialects and create a context to work with.
+    mlir::DialectRegistry registry;
+
+    // Register MLIR dialects.
+    registry.insert<mlir::affine::AffineDialect>();
+    registry.insert<mlir::memref::MemRefDialect>();
+    registry.insert<mlir::func::FuncDialect>();
+    registry.insert<mlir::arith::ArithDialect>();
+    registry.insert<mlir::cf::ControlFlowDialect>();
+    registry.insert<mlir::scf::SCFDialect>();
+
+    // Register MLIR passes.
+    mlir::registerCSEPass();
+    mlir::registerSCCPPass();
+    mlir::registerInlinerPass();
+    mlir::registerCanonicalizerPass();
+
+    // Register CIRCT dialects.
+    registry.insert<circt::hw::HWDialect, circt::comb::CombDialect, circt::seq::SeqDialect>();
+
+    mlir::MLIRContext context(registry);
+
+    auto result = executeHls(context);
+
+    // Use "exit" instead of return'ing to signal completion.  This avoids
+    // invoking the MLIRContext destructor, which spends a bunch of time
+    // deallocating memory etc which process exit will do for us.
+     exit(llvm::failed(result));
+}
+
+
+


### PR DESCRIPTION
【需求编号】
US-012

【需求描述】
在EquivFusion中增加equivfusion-hls工具，实现HLS flow。将Polygeist生成的mlir转换成core dialects。

【一句话总结实现】
1）支持HLS flow将SCF/Arith/Affine组成的MLIR转换成core dialect组成的组合逻辑电路
2）添加五个case，分别测试lzc c代码调用不同求解器证明与RTL二分法实现的等价性

【实现细节】
1）使用Polygeist将c代码转换成MLIR
2）对Affine loop进行循环展开，消除循环控制流
3）循环展开后的MLIR执行Affine to SCF的转换
4）SCF to CF转换
5）将Arith方言中的operation转换成comb方言中的operation
6）消除mlir中的条件控制流，将所有basic block都合并到entry block中
7）根据经过上述处理后的mlir生成hw.module

【自测结果】
z3、bitwuzla、btormc、kissat均可证明equivfusion-hls处理后的mlir与通过circt-verilog产生的RTL二分法的mlir等价