### PR TITLE
[Frontend][US-012]: Add '--top' option for equivfusion-hls to remove …

### DIFF
--- a/include/circt-passes/CMakeLists.txt
+++ b/include/circt-passes/CMakeLists.txt
@@ -1,3 +1,4 @@
 add_subdirectory(Miter)
 add_subdirectory(DecomposeConcat)
 add_subdirectory(FuncToHWModule)
+add_subdirectory(RemoveRedundantFunc)

--- a/include/circt-passes/RemoveRedundantFunc/CMakeLists.txt
+++ b/include/circt-passes/RemoveRedundantFunc/CMakeLists.txt
@@ -1,0 +1,8 @@
+set(LLVM_TARGET_DEFINITIONS Passes.td) 
+
+mlir_tablegen(Passes.h.inc -gen-pass-decls -name EquivFusionRemoveRedundantFunc) 
+
+mlir_tablegen(EquivFusionRemoveRedundantFunc.capi.h.inc -gen-pass-capi-header --prefix EquivFusionRemoveRedundantFunc)
+mlir_tablegen(EquivFusionRemoveRedundantFunc.capi.cpp.inc -gen-pass-capi-impl --prefix EquivFusionRemoveRedundantFunc)
+
+add_public_tablegen_target(EquivFusionRemoveRedundantFuncIncGen)

--- a/include/circt-passes/RemoveRedundantFunc/Passes.h
+++ b/include/circt-passes/RemoveRedundantFunc/Passes.h
@@ -1,0 +1,12 @@
+#pragma once
+
+#include "mlir/Pass/Pass.h"
+
+namespace circt {
+
+/// Generate the code for registering passes.
+#define GEN_PASS_DECL_EQUIVFUSIONREMOVEREDUNDANTFUNCPASS
+#define GEN_PASS_REGISTRATION
+#include "circt-passes/RemoveRedundantFunc/Passes.h.inc"
+ 
+} // namespace circt

--- a/include/circt-passes/RemoveRedundantFunc/Passes.td
+++ b/include/circt-passes/RemoveRedundantFunc/Passes.td
@@ -1,0 +1,22 @@
+#ifndef EQUIVFUSION_REMOVE_REDUNDANT_FUNC_TD
+#define EQUIVFUSION_REMOVE_REDUNDANT_FUNC_TD
+
+include "mlir/Pass/PassBase.td"
+
+def EquivFusionRemoveRedundantFuncPass : Pass<"equivfusion-remove-redundant-func", "mlir::ModuleOp"> {
+    let summary = "Remove Redundant Func in 'builtin.module'";
+
+    let description = [{
+        This Pass Removes func.func except top func in 'builtin.module'.
+    }];
+
+    let dependentDialects = ["mlir::func::FuncDialect"];
+
+    let options = [
+        Option<"topFunc", "equivfusion-remove-redundant-func-top-func", 
+               "std::string", /*default*/"", "Name of top func.">
+    ];
+}
+
+
+#endif // EQUIVFUSION_REMOVE_REDUNDANT_FUNC_TD

--- a/infrastructure/circt-passes/CMakeLists.txt
+++ b/infrastructure/circt-passes/CMakeLists.txt
@@ -1,3 +1,4 @@
 add_subdirectory(Miter)
 add_subdirectory(DecomposeConcat)
 add_subdirectory(FuncToHWModule)
+add_subdirectory(RemoveRedundantFunc)

--- a/infrastructure/circt-passes/RemoveRedundantFunc/CMakeLists.txt
+++ b/infrastructure/circt-passes/RemoveRedundantFunc/CMakeLists.txt
@@ -1,0 +1,9 @@
+add_circt_library(EquivFusionRemoveRedundantFunc
+    equivfusion_remove_redundant_func.cpp
+
+    DEPENDS
+    EquivFusionRemoveRedundantFuncIncGen
+
+    LINK_LIBS PUBLIC
+    MLIRFuncDialect
+)

--- a/infrastructure/circt-passes/RemoveRedundantFunc/equivfusion_remove_redundant_func.cpp
+++ b/infrastructure/circt-passes/RemoveRedundantFunc/equivfusion_remove_redundant_func.cpp
@@ -1,0 +1,37 @@
+#include "circt-passes/RemoveRedundantFunc/Passes.h"
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/IR/BuiltinOps.h"
+
+
+namespace circt {
+
+#define GEN_PASS_DEF_EQUIVFUSIONREMOVEREDUNDANTFUNCPASS
+#include "circt-passes/RemoveRedundantFunc/Passes.h.inc"
+
+} // namespace circt
+
+
+
+namespace {
+
+struct EquivFusionRemoveRedundantPass : public circt::impl::EquivFusionRemoveRedundantFuncPassBase<EquivFusionRemoveRedundantPass> {
+    using circt::impl::EquivFusionRemoveRedundantFuncPassBase<EquivFusionRemoveRedundantPass>::EquivFusionRemoveRedundantFuncPassBase;
+
+    void runOnOperation() override;
+};
+
+}
+
+void EquivFusionRemoveRedundantPass::runOnOperation() {
+    for (auto funcOp : llvm::make_early_inc_range(getOperation().getOps<mlir::func::FuncOp>())) {
+        if (funcOp.getSymName() == this->topFunc) {
+            continue;
+        }
+        funcOp.erase();
+    }
+}
+
+
+
+
+

--- a/test/integration_tests/cases/specify_top_function_test/design.mlir
+++ b/test/integration_tests/cases/specify_top_function_test/design.mlir
@@ -1,0 +1,24 @@
+module {
+  func.func @increment(%arg0: i32) -> i32 attributes {llvm.linkage = #llvm.linkage<external>} {
+    %c1_i32 = arith.constant 1 : i32
+    %0 = arith.addi %arg0, %c1_i32 : i32
+    return %0 : i32
+  }
+  func.func @test(%arg0: i8, %arg1: i32) -> i32 attributes {llvm.linkage = #llvm.linkage<external>} {
+    %c1_i32 = arith.constant 1 : i32
+    %c0_i8 = arith.constant 0 : i8
+    %c0_i32 = arith.constant 0 : i32
+    %0 = arith.cmpi ne, %arg0, %c0_i8 : i8
+    %1 = affine.for %arg2 = 0 to 3 iter_args(%arg3 = %c0_i32) -> (i32) {
+      %2 = scf.if %0 -> (i32) {
+        %3 = arith.addi %arg3, %arg1 : i32
+        scf.yield %3 : i32
+      } else {
+        %3 = arith.addi %arg3, %c1_i32 : i32
+        scf.yield %3 : i32
+      }
+      affine.yield %2 : i32
+    }
+    return %1 : i32
+  }
+}

--- a/test/integration_tests/cases/specify_top_function_test/specify_top_function_test.sh
+++ b/test/integration_tests/cases/specify_top_function_test/specify_top_function_test.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/bash
+
+set -euo pipefail
+
+CASE_DIR=$(dirname "$(realpath "$0")")
+
+equivfusion-hls "$CASE_DIR/design.mlir" -top "test"
+
+#CHECK-NOT: hw.module @increment

--- a/tools/equivfusion-hls/CMakeLists.txt
+++ b/tools/equivfusion-hls/CMakeLists.txt
@@ -23,6 +23,7 @@ target_link_libraries(equivfusion-hls
   MLIRAffineToStandard
 
   FuncToHWModule
+  EquivFusionRemoveRedundantFunc
   log
 )
 


### PR DESCRIPTION
【需求编号】
US-012

【需求描述】
为equivfusion-hls增加一个--top的option。指定top function时，只保留top function，删除其他functions。不指定则保留所有functions

【一句话总结实现】
遍历builtin.module中的所有func.func，删除掉名字与top function不同的func.func

【实现细节】
1）增加--top的option，用于接收保存top function name。
2）增加EquivFsuionRemoveRedundantPass，遍历所有func.func，删除名字与top function不同的func.func

【自测结果】
增加integrate_test/cases/specify_top_function_test，跑FileCheck可以Pass

