### PR TITLE
[Frontend][US-012]:Get names of parameters of func.func.

### DIFF
--- a/infrastructure/circt-passes/FuncToHWModule/func_to_hw_module.cpp
+++ b/infrastructure/circt-passes/FuncToHWModule/func_to_hw_module.cpp
@@ -364,9 +364,7 @@ FuncToHWModulePass::buildHWModuleOPFromFuncOP(mlir::OpBuilder &builder, mlir::fu
             mlir::Attribute argAttr = (*argAttrs)[idx];
             mlir::DictionaryAttr dictAttr = llvm::dyn_cast_or_null<mlir::DictionaryAttr>(argAttr);
             if (dictAttr) {
-                if (mlir::StringAttr nameAttr = dictAttr.getAs<mlir::StringAttr>("name")) { 
-                    inputName = nameAttr.getValue().str();
-                } else if (mlir::StringAttr nameAttr = dictAttr.getAs<mlir::StringAttr>("sym_name")) {
+                if (mlir::StringAttr nameAttr = dictAttr.getAs<mlir::StringAttr>("polygeist.param_name")) { 
                     inputName = nameAttr.getValue().str();
                 }
             }

--- a/test/integration_tests/cases/lzc_c_to_dichotomy_run_bitwuzla_with_btor2/LZC.c
+++ b/test/integration_tests/cases/lzc_c_to_dichotomy_run_bitwuzla_with_btor2/LZC.c
@@ -12,12 +12,12 @@ void LZC(uint8_t data_in, uint8_t *lzc) {
 }
 */
 
-uint8_t LZC(uint8_t data_in) {
+uint8_t LZC(uint8_t mant_in) {
     uint8_t count = 0;
     bool skip = false;
     for (int i = 7; i >= 1; i--) {
     	if (!skip) {
-	    if ((data_in >> i) & 1) {
+	    if ((mant_in >> i) & 1) {
 	        skip = true;
 	    } else {
 	        count++;

--- a/test/integration_tests/cases/lzc_c_to_dichotomy_run_bitwuzla_with_btor2/LZC.mlir
+++ b/test/integration_tests/cases/lzc_c_to_dichotomy_run_bitwuzla_with_btor2/LZC.mlir
@@ -1,5 +1,5 @@
 module {
-  func.func @LZC(%arg0: i8) -> i8 attributes {llvm.linkage = #llvm.linkage<external>} {
+  func.func @LZC(%arg0: i8 {polygeist.param_name = "mant_in"}) -> i8 attributes {llvm.linkage = #llvm.linkage<external>} {
     %c8 = arith.constant 8 : index
     %c1_i8 = arith.constant 1 : i8
     %c0_i32 = arith.constant 0 : i32

--- a/test/integration_tests/cases/lzc_c_to_dichotomy_run_bitwuzla_with_btor2/lzc_dichotomy.mlir
+++ b/test/integration_tests/cases/lzc_c_to_dichotomy_run_bitwuzla_with_btor2/lzc_dichotomy.mlir
@@ -1,22 +1,22 @@
 module {
-  hw.module @lzc7_dichotomy(in %in_0 : i8, out out_0 : i8) {
+  hw.module @lzc7_dichotomy(in %mant_in : i8, out out_0 : i8) {
     %c-1_i3 = hw.constant -1 : i3
     %c0_i2 = hw.constant 0 : i2
     %c0_i4 = hw.constant 0 : i4
     %c0_i5 = hw.constant 0 : i5
     %0 = comb.concat %2, %7, %14 : i1, i1, i1
-    %1 = comb.extract %in_0 from 4 : (i8) -> i4
+    %1 = comb.extract %mant_in from 4 : (i8) -> i4
     %2 = comb.icmp ne %1, %c0_i4 : i4
-    %3 = comb.extract %in_0 from 6 : (i8) -> i2
+    %3 = comb.extract %mant_in from 6 : (i8) -> i2
     %4 = comb.icmp ne %3, %c0_i2 : i2
-    %5 = comb.extract %in_0 from 2 : (i8) -> i2
+    %5 = comb.extract %mant_in from 2 : (i8) -> i2
     %6 = comb.icmp ne %5, %c0_i2 : i2
     %7 = comb.mux %2, %4, %6 : i1
-    %8 = comb.extract %in_0 from 7 : (i8) -> i1
-    %9 = comb.extract %in_0 from 5 : (i8) -> i1
+    %8 = comb.extract %mant_in from 7 : (i8) -> i1
+    %9 = comb.extract %mant_in from 5 : (i8) -> i1
     %10 = comb.mux %4, %8, %9 : i1
-    %11 = comb.extract %in_0 from 3 : (i8) -> i1
-    %12 = comb.extract %in_0 from 1 : (i8) -> i1
+    %11 = comb.extract %mant_in from 3 : (i8) -> i1
+    %12 = comb.extract %mant_in from 1 : (i8) -> i1
     %13 = comb.mux %6, %11, %12 : i1
     %14 = comb.mux %2, %10, %13 : i1
     %15 = comb.xor %0, %c-1_i3 : i3

--- a/test/integration_tests/cases/lzc_c_to_dichotomy_run_bitwuzla_with_btor2/lzc_dichotomy.v
+++ b/test/integration_tests/cases/lzc_c_to_dichotomy_run_bitwuzla_with_btor2/lzc_dichotomy.v
@@ -1,16 +1,16 @@
 module lzc7_dichotomy
 (
-    input   [7:0]   in_0,
+    input   [7:0]   mant_in,
         
     output  [7:0]   out_0                                
 );
 
 wire [2:0] leading_one ;
 
-assign leading_one[2] = |in_0[7:4] ;
-assign leading_one[1] = (|in_0[7:4]) ? (|in_0[7:6]) : (|in_0[3:2]) ;
-assign leading_one[0] = (|in_0[7:4]) ? (|in_0[7:6]) ? in_0[7] : in_0[5] : (|in_0[3:2]) ? in_0[3] : in_0[1] ;
-//(|in_0[6:3]) ? (in_0[6] | (~in_0[5] & in_0[4])) : (in_0[2] | (~in_0[1] & in_0[0])) ;
+assign leading_one[2] = |mant_in[7:4] ;
+assign leading_one[1] = (|mant_in[7:4]) ? (|mant_in[7:6]) : (|mant_in[3:2]) ;
+assign leading_one[0] = (|mant_in[7:4]) ? (|mant_in[7:6]) ? mant_in[7] : mant_in[5] : (|mant_in[3:2]) ? mant_in[3] : mant_in[1] ;
+//(|mant_in[6:3]) ? (mant_in[6] | (~mant_in[5] & mant_in[4])) : (mant_in[2] | (~mant_in[1] & mant_in[0])) ;
 
 assign out_0 = {5'h0, ~leading_one};
 

--- a/test/integration_tests/cases/lzc_c_to_dichotomy_run_bitwuzla_with_smt2/LZC.c
+++ b/test/integration_tests/cases/lzc_c_to_dichotomy_run_bitwuzla_with_smt2/LZC.c
@@ -12,12 +12,12 @@ void LZC(uint8_t data_in, uint8_t *lzc) {
 }
 */
 
-uint8_t LZC(uint8_t data_in) {
+uint8_t LZC(uint8_t mant_in) {
     uint8_t count = 0;
     bool skip = false;
     for (int i = 7; i >= 1; i--) {
     	if (!skip) {
-	    if ((data_in >> i) & 1) {
+	    if ((mant_in >> i) & 1) {
 	        skip = true;
 	    } else {
 	        count++;

--- a/test/integration_tests/cases/lzc_c_to_dichotomy_run_bitwuzla_with_smt2/LZC.mlir
+++ b/test/integration_tests/cases/lzc_c_to_dichotomy_run_bitwuzla_with_smt2/LZC.mlir
@@ -1,5 +1,5 @@
 module {
-  func.func @LZC(%arg0: i8) -> i8 attributes {llvm.linkage = #llvm.linkage<external>} {
+  func.func @LZC(%arg0: i8 {polygeist.param_name = "mant_in"}) -> i8 attributes {llvm.linkage = #llvm.linkage<external>} {
     %c8 = arith.constant 8 : index
     %c1_i8 = arith.constant 1 : i8
     %c0_i32 = arith.constant 0 : i32

--- a/test/integration_tests/cases/lzc_c_to_dichotomy_run_bitwuzla_with_smt2/lzc_dichotomy.mlir
+++ b/test/integration_tests/cases/lzc_c_to_dichotomy_run_bitwuzla_with_smt2/lzc_dichotomy.mlir
@@ -1,22 +1,22 @@
 module {
-  hw.module @lzc7_dichotomy(in %in_0 : i8, out out_0 : i8) {
+  hw.module @lzc7_dichotomy(in %mant_in : i8, out out_0 : i8) {
     %c-1_i3 = hw.constant -1 : i3
     %c0_i2 = hw.constant 0 : i2
     %c0_i4 = hw.constant 0 : i4
     %c0_i5 = hw.constant 0 : i5
     %0 = comb.concat %2, %7, %14 : i1, i1, i1
-    %1 = comb.extract %in_0 from 4 : (i8) -> i4
+    %1 = comb.extract %mant_in from 4 : (i8) -> i4
     %2 = comb.icmp ne %1, %c0_i4 : i4
-    %3 = comb.extract %in_0 from 6 : (i8) -> i2
+    %3 = comb.extract %mant_in from 6 : (i8) -> i2
     %4 = comb.icmp ne %3, %c0_i2 : i2
-    %5 = comb.extract %in_0 from 2 : (i8) -> i2
+    %5 = comb.extract %mant_in from 2 : (i8) -> i2
     %6 = comb.icmp ne %5, %c0_i2 : i2
     %7 = comb.mux %2, %4, %6 : i1
-    %8 = comb.extract %in_0 from 7 : (i8) -> i1
-    %9 = comb.extract %in_0 from 5 : (i8) -> i1
+    %8 = comb.extract %mant_in from 7 : (i8) -> i1
+    %9 = comb.extract %mant_in from 5 : (i8) -> i1
     %10 = comb.mux %4, %8, %9 : i1
-    %11 = comb.extract %in_0 from 3 : (i8) -> i1
-    %12 = comb.extract %in_0 from 1 : (i8) -> i1
+    %11 = comb.extract %mant_in from 3 : (i8) -> i1
+    %12 = comb.extract %mant_in from 1 : (i8) -> i1
     %13 = comb.mux %6, %11, %12 : i1
     %14 = comb.mux %2, %10, %13 : i1
     %15 = comb.xor %0, %c-1_i3 : i3

--- a/test/integration_tests/cases/lzc_c_to_dichotomy_run_bitwuzla_with_smt2/lzc_dichotomy.v
+++ b/test/integration_tests/cases/lzc_c_to_dichotomy_run_bitwuzla_with_smt2/lzc_dichotomy.v
@@ -1,16 +1,16 @@
 module lzc7_dichotomy
 (
-    input   [7:0]   in_0,
+    input   [7:0]   mant_in,
         
     output  [7:0]   out_0                                
 );
 
 wire [2:0] leading_one ;
 
-assign leading_one[2] = |in_0[7:4] ;
-assign leading_one[1] = (|in_0[7:4]) ? (|in_0[7:6]) : (|in_0[3:2]) ;
-assign leading_one[0] = (|in_0[7:4]) ? (|in_0[7:6]) ? in_0[7] : in_0[5] : (|in_0[3:2]) ? in_0[3] : in_0[1] ;
-//(|in_0[6:3]) ? (in_0[6] | (~in_0[5] & in_0[4])) : (in_0[2] | (~in_0[1] & in_0[0])) ;
+assign leading_one[2] = |mant_in[7:4] ;
+assign leading_one[1] = (|mant_in[7:4]) ? (|mant_in[7:6]) : (|mant_in[3:2]) ;
+assign leading_one[0] = (|mant_in[7:4]) ? (|mant_in[7:6]) ? mant_in[7] : mant_in[5] : (|mant_in[3:2]) ? mant_in[3] : mant_in[1] ;
+//(|mant_in[6:3]) ? (mant_in[6] | (~mant_in[5] & mant_in[4])) : (mant_in[2] | (~mant_in[1] & mant_in[0])) ;
 
 assign out_0 = {5'h0, ~leading_one};
 

--- a/test/integration_tests/cases/lzc_c_to_dichotomy_run_btormc_with_btor2/LZC.c
+++ b/test/integration_tests/cases/lzc_c_to_dichotomy_run_btormc_with_btor2/LZC.c
@@ -12,12 +12,12 @@ void LZC(uint8_t data_in, uint8_t *lzc) {
 }
 */
 
-uint8_t LZC(uint8_t data_in) {
+uint8_t LZC(uint8_t mant_in) {
     uint8_t count = 0;
     bool skip = false;
     for (int i = 7; i >= 1; i--) {
     	if (!skip) {
-	    if ((data_in >> i) & 1) {
+	    if ((mant_in >> i) & 1) {
 	        skip = true;
 	    } else {
 	        count++;

--- a/test/integration_tests/cases/lzc_c_to_dichotomy_run_btormc_with_btor2/LZC.mlir
+++ b/test/integration_tests/cases/lzc_c_to_dichotomy_run_btormc_with_btor2/LZC.mlir
@@ -1,5 +1,5 @@
 module {
-  func.func @LZC(%arg0: i8) -> i8 attributes {llvm.linkage = #llvm.linkage<external>} {
+  func.func @LZC(%arg0: i8 {polygeist.param_name = "mant_in"}) -> i8 attributes {llvm.linkage = #llvm.linkage<external>} {
     %c8 = arith.constant 8 : index
     %c1_i8 = arith.constant 1 : i8
     %c0_i32 = arith.constant 0 : i32

--- a/test/integration_tests/cases/lzc_c_to_dichotomy_run_btormc_with_btor2/lzc_dichotomy.mlir
+++ b/test/integration_tests/cases/lzc_c_to_dichotomy_run_btormc_with_btor2/lzc_dichotomy.mlir
@@ -1,22 +1,22 @@
 module {
-  hw.module @lzc7_dichotomy(in %in_0 : i8, out out_0 : i8) {
+  hw.module @lzc7_dichotomy(in %mant_in : i8, out out_0 : i8) {
     %c-1_i3 = hw.constant -1 : i3
     %c0_i2 = hw.constant 0 : i2
     %c0_i4 = hw.constant 0 : i4
     %c0_i5 = hw.constant 0 : i5
     %0 = comb.concat %2, %7, %14 : i1, i1, i1
-    %1 = comb.extract %in_0 from 4 : (i8) -> i4
+    %1 = comb.extract %mant_in from 4 : (i8) -> i4
     %2 = comb.icmp ne %1, %c0_i4 : i4
-    %3 = comb.extract %in_0 from 6 : (i8) -> i2
+    %3 = comb.extract %mant_in from 6 : (i8) -> i2
     %4 = comb.icmp ne %3, %c0_i2 : i2
-    %5 = comb.extract %in_0 from 2 : (i8) -> i2
+    %5 = comb.extract %mant_in from 2 : (i8) -> i2
     %6 = comb.icmp ne %5, %c0_i2 : i2
     %7 = comb.mux %2, %4, %6 : i1
-    %8 = comb.extract %in_0 from 7 : (i8) -> i1
-    %9 = comb.extract %in_0 from 5 : (i8) -> i1
+    %8 = comb.extract %mant_in from 7 : (i8) -> i1
+    %9 = comb.extract %mant_in from 5 : (i8) -> i1
     %10 = comb.mux %4, %8, %9 : i1
-    %11 = comb.extract %in_0 from 3 : (i8) -> i1
-    %12 = comb.extract %in_0 from 1 : (i8) -> i1
+    %11 = comb.extract %mant_in from 3 : (i8) -> i1
+    %12 = comb.extract %mant_in from 1 : (i8) -> i1
     %13 = comb.mux %6, %11, %12 : i1
     %14 = comb.mux %2, %10, %13 : i1
     %15 = comb.xor %0, %c-1_i3 : i3

--- a/test/integration_tests/cases/lzc_c_to_dichotomy_run_btormc_with_btor2/lzc_dichotomy.v
+++ b/test/integration_tests/cases/lzc_c_to_dichotomy_run_btormc_with_btor2/lzc_dichotomy.v
@@ -1,16 +1,16 @@
 module lzc7_dichotomy
 (
-    input   [7:0]   in_0,
+    input   [7:0]   mant_in,
         
     output  [7:0]   out_0                                
 );
 
 wire [2:0] leading_one ;
 
-assign leading_one[2] = |in_0[7:4] ;
-assign leading_one[1] = (|in_0[7:4]) ? (|in_0[7:6]) : (|in_0[3:2]) ;
-assign leading_one[0] = (|in_0[7:4]) ? (|in_0[7:6]) ? in_0[7] : in_0[5] : (|in_0[3:2]) ? in_0[3] : in_0[1] ;
-//(|in_0[6:3]) ? (in_0[6] | (~in_0[5] & in_0[4])) : (in_0[2] | (~in_0[1] & in_0[0])) ;
+assign leading_one[2] = |mant_in[7:4] ;
+assign leading_one[1] = (|mant_in[7:4]) ? (|mant_in[7:6]) : (|mant_in[3:2]) ;
+assign leading_one[0] = (|mant_in[7:4]) ? (|mant_in[7:6]) ? mant_in[7] : mant_in[5] : (|mant_in[3:2]) ? mant_in[3] : mant_in[1] ;
+//(|mant_in[6:3]) ? (mant_in[6] | (~mant_in[5] & mant_in[4])) : (mant_in[2] | (~mant_in[1] & mant_in[0])) ;
 
 assign out_0 = {5'h0, ~leading_one};
 

--- a/test/integration_tests/cases/lzc_c_to_dichotomy_run_kissat/LZC.c
+++ b/test/integration_tests/cases/lzc_c_to_dichotomy_run_kissat/LZC.c
@@ -12,12 +12,12 @@ void LZC(uint8_t data_in, uint8_t *lzc) {
 }
 */
 
-uint8_t LZC(uint8_t data_in) {
+uint8_t LZC(uint8_t mant_in) {
     uint8_t count = 0;
     bool skip = false;
     for (int i = 7; i >= 1; i--) {
     	if (!skip) {
-	    if ((data_in >> i) & 1) {
+	    if ((mant_in >> i) & 1) {
 	        skip = true;
 	    } else {
 	        count++;

--- a/test/integration_tests/cases/lzc_c_to_dichotomy_run_kissat/LZC.mlir
+++ b/test/integration_tests/cases/lzc_c_to_dichotomy_run_kissat/LZC.mlir
@@ -1,5 +1,5 @@
 module {
-  func.func @LZC(%arg0: i8) -> i8 attributes {llvm.linkage = #llvm.linkage<external>} {
+  func.func @LZC(%arg0: i8 {polygeist.param_name = "mant_in"}) -> i8 attributes {llvm.linkage = #llvm.linkage<external>} {
     %c8 = arith.constant 8 : index
     %c1_i8 = arith.constant 1 : i8
     %c0_i32 = arith.constant 0 : i32

--- a/test/integration_tests/cases/lzc_c_to_dichotomy_run_kissat/lzc_dichotomy.mlir
+++ b/test/integration_tests/cases/lzc_c_to_dichotomy_run_kissat/lzc_dichotomy.mlir
@@ -1,22 +1,22 @@
 module {
-  hw.module @lzc7_dichotomy(in %in_0 : i8, out out_0 : i8) {
+  hw.module @lzc7_dichotomy(in %mant_in : i8, out out_0 : i8) {
     %c-1_i3 = hw.constant -1 : i3
     %c0_i2 = hw.constant 0 : i2
     %c0_i4 = hw.constant 0 : i4
     %c0_i5 = hw.constant 0 : i5
     %0 = comb.concat %2, %7, %14 : i1, i1, i1
-    %1 = comb.extract %in_0 from 4 : (i8) -> i4
+    %1 = comb.extract %mant_in from 4 : (i8) -> i4
     %2 = comb.icmp ne %1, %c0_i4 : i4
-    %3 = comb.extract %in_0 from 6 : (i8) -> i2
+    %3 = comb.extract %mant_in from 6 : (i8) -> i2
     %4 = comb.icmp ne %3, %c0_i2 : i2
-    %5 = comb.extract %in_0 from 2 : (i8) -> i2
+    %5 = comb.extract %mant_in from 2 : (i8) -> i2
     %6 = comb.icmp ne %5, %c0_i2 : i2
     %7 = comb.mux %2, %4, %6 : i1
-    %8 = comb.extract %in_0 from 7 : (i8) -> i1
-    %9 = comb.extract %in_0 from 5 : (i8) -> i1
+    %8 = comb.extract %mant_in from 7 : (i8) -> i1
+    %9 = comb.extract %mant_in from 5 : (i8) -> i1
     %10 = comb.mux %4, %8, %9 : i1
-    %11 = comb.extract %in_0 from 3 : (i8) -> i1
-    %12 = comb.extract %in_0 from 1 : (i8) -> i1
+    %11 = comb.extract %mant_in from 3 : (i8) -> i1
+    %12 = comb.extract %mant_in from 1 : (i8) -> i1
     %13 = comb.mux %6, %11, %12 : i1
     %14 = comb.mux %2, %10, %13 : i1
     %15 = comb.xor %0, %c-1_i3 : i3

--- a/test/integration_tests/cases/lzc_c_to_dichotomy_run_kissat/lzc_dichotomy.v
+++ b/test/integration_tests/cases/lzc_c_to_dichotomy_run_kissat/lzc_dichotomy.v
@@ -1,16 +1,16 @@
 module lzc7_dichotomy
 (
-    input   [7:0]   in_0,
+    input   [7:0]   mant_in,
         
     output  [7:0]   out_0                                
 );
 
 wire [2:0] leading_one ;
 
-assign leading_one[2] = |in_0[7:4] ;
-assign leading_one[1] = (|in_0[7:4]) ? (|in_0[7:6]) : (|in_0[3:2]) ;
-assign leading_one[0] = (|in_0[7:4]) ? (|in_0[7:6]) ? in_0[7] : in_0[5] : (|in_0[3:2]) ? in_0[3] : in_0[1] ;
-//(|in_0[6:3]) ? (in_0[6] | (~in_0[5] & in_0[4])) : (in_0[2] | (~in_0[1] & in_0[0])) ;
+assign leading_one[2] = |mant_in[7:4] ;
+assign leading_one[1] = (|mant_in[7:4]) ? (|mant_in[7:6]) : (|mant_in[3:2]) ;
+assign leading_one[0] = (|mant_in[7:4]) ? (|mant_in[7:6]) ? mant_in[7] : mant_in[5] : (|mant_in[3:2]) ? mant_in[3] : mant_in[1] ;
+//(|mant_in[6:3]) ? (mant_in[6] | (~mant_in[5] & mant_in[4])) : (mant_in[2] | (~mant_in[1] & mant_in[0])) ;
 
 assign out_0 = {5'h0, ~leading_one};
 

--- a/test/integration_tests/cases/lzc_c_to_dichotomy_run_z3_with_smt2/LZC.c
+++ b/test/integration_tests/cases/lzc_c_to_dichotomy_run_z3_with_smt2/LZC.c
@@ -12,12 +12,12 @@ void LZC(uint8_t data_in, uint8_t *lzc) {
 }
 */
 
-uint8_t LZC(uint8_t data_in) {
+uint8_t LZC(uint8_t mant_in) {
     uint8_t count = 0;
     bool skip = false;
     for (int i = 7; i >= 1; i--) {
     	if (!skip) {
-	    if ((data_in >> i) & 1) {
+	    if ((mant_in >> i) & 1) {
 	        skip = true;
 	    } else {
 	        count++;

--- a/test/integration_tests/cases/lzc_c_to_dichotomy_run_z3_with_smt2/LZC.mlir
+++ b/test/integration_tests/cases/lzc_c_to_dichotomy_run_z3_with_smt2/LZC.mlir
@@ -1,5 +1,5 @@
 module {
-  func.func @LZC(%arg0: i8) -> i8 attributes {llvm.linkage = #llvm.linkage<external>} {
+  func.func @LZC(%arg0: i8 {polygeist.param_name = "mant_in"}) -> i8 attributes {llvm.linkage = #llvm.linkage<external>} {
     %c8 = arith.constant 8 : index
     %c1_i8 = arith.constant 1 : i8
     %c0_i32 = arith.constant 0 : i32

--- a/test/integration_tests/cases/lzc_c_to_dichotomy_run_z3_with_smt2/lzc_dichotomy.mlir
+++ b/test/integration_tests/cases/lzc_c_to_dichotomy_run_z3_with_smt2/lzc_dichotomy.mlir
@@ -1,22 +1,22 @@
 module {
-  hw.module @lzc7_dichotomy(in %in_0 : i8, out out_0 : i8) {
+  hw.module @lzc7_dichotomy(in %mant_in : i8, out out_0 : i8) {
     %c-1_i3 = hw.constant -1 : i3
     %c0_i2 = hw.constant 0 : i2
     %c0_i4 = hw.constant 0 : i4
     %c0_i5 = hw.constant 0 : i5
     %0 = comb.concat %2, %7, %14 : i1, i1, i1
-    %1 = comb.extract %in_0 from 4 : (i8) -> i4
+    %1 = comb.extract %mant_in from 4 : (i8) -> i4
     %2 = comb.icmp ne %1, %c0_i4 : i4
-    %3 = comb.extract %in_0 from 6 : (i8) -> i2
+    %3 = comb.extract %mant_in from 6 : (i8) -> i2
     %4 = comb.icmp ne %3, %c0_i2 : i2
-    %5 = comb.extract %in_0 from 2 : (i8) -> i2
+    %5 = comb.extract %mant_in from 2 : (i8) -> i2
     %6 = comb.icmp ne %5, %c0_i2 : i2
     %7 = comb.mux %2, %4, %6 : i1
-    %8 = comb.extract %in_0 from 7 : (i8) -> i1
-    %9 = comb.extract %in_0 from 5 : (i8) -> i1
+    %8 = comb.extract %mant_in from 7 : (i8) -> i1
+    %9 = comb.extract %mant_in from 5 : (i8) -> i1
     %10 = comb.mux %4, %8, %9 : i1
-    %11 = comb.extract %in_0 from 3 : (i8) -> i1
-    %12 = comb.extract %in_0 from 1 : (i8) -> i1
+    %11 = comb.extract %mant_in from 3 : (i8) -> i1
+    %12 = comb.extract %mant_in from 1 : (i8) -> i1
     %13 = comb.mux %6, %11, %12 : i1
     %14 = comb.mux %2, %10, %13 : i1
     %15 = comb.xor %0, %c-1_i3 : i3

--- a/test/integration_tests/cases/lzc_c_to_dichotomy_run_z3_with_smt2/lzc_dichotomy.v
+++ b/test/integration_tests/cases/lzc_c_to_dichotomy_run_z3_with_smt2/lzc_dichotomy.v
@@ -1,16 +1,16 @@
 module lzc7_dichotomy
 (
-    input   [7:0]   in_0,
+    input   [7:0]   mant_in,
         
     output  [7:0]   out_0                                
 );
 
 wire [2:0] leading_one ;
 
-assign leading_one[2] = |in_0[7:4] ;
-assign leading_one[1] = (|in_0[7:4]) ? (|in_0[7:6]) : (|in_0[3:2]) ;
-assign leading_one[0] = (|in_0[7:4]) ? (|in_0[7:6]) ? in_0[7] : in_0[5] : (|in_0[3:2]) ? in_0[3] : in_0[1] ;
-//(|in_0[6:3]) ? (in_0[6] | (~in_0[5] & in_0[4])) : (in_0[2] | (~in_0[1] & in_0[0])) ;
+assign leading_one[2] = |mant_in[7:4] ;
+assign leading_one[1] = (|mant_in[7:4]) ? (|mant_in[7:6]) : (|mant_in[3:2]) ;
+assign leading_one[0] = (|mant_in[7:4]) ? (|mant_in[7:6]) ? mant_in[7] : mant_in[5] : (|mant_in[3:2]) ? mant_in[3] : mant_in[1] ;
+//(|mant_in[6:3]) ? (mant_in[6] | (~mant_in[5] & mant_in[4])) : (mant_in[2] | (~mant_in[1] & mant_in[0])) ;
 
 assign out_0 = {5'h0, ~leading_one};
 


### PR DESCRIPTION
【需求编号】
US-012

【需求描述】
将func.func转换成hw.module时，从parameter对用的属性列表中获取parameter的名字，目的是使得生成的module的input端口的名称是func的对应参数的名字

【一句话总结实现】
从parameter对应的属性列表中，查找polygeist.param_name对应的属性值，得到参数名称

【实现细节】
1）修改Polygeist代码，在将AST转换生成MLIR时，将函数参数的名称添加到其对应的属性列表中，并使用polygiest.param_name作为索引的key
2）在EquivFusion中将func.func转换成hw.module时，获取polygeist.param_name对应的值

【自测结果】
LZC case测试通过