### PR TITLE
[Backend][US-013]: fix write_command clean the moduleOp

### DIFF
--- a/infrastructure/base/write_command.cpp
+++ b/infrastructure/base/write_command.cpp
@@ -19,10 +19,7 @@ public:
     void execute(const std::vector<std::string>& args) override {
         mlir::MLIRContext& context = *EquivFusionManager::getInstance()->getGlobalContext();
         mlir::ModuleOp inputModule = EquivFusionManager::getInstance()->getModuleOp();
-        mlir::OwningOpRef<mlir::ModuleOp> outputModule;
-        if (Impl::run(args, context, inputModule, outputModule)) {
-            EquivFusionManager::getInstance()->setModuleOp(outputModule);
-        }
+        Impl::run(args, context, inputModule);
     }
 
     void postExecute() override {

--- a/libs/Write/aiger/aiger.cpp
+++ b/libs/Write/aiger/aiger.cpp
@@ -11,8 +11,11 @@
 
 XUANSONG_NAMESPACE_HEADER_START
 
-bool WriteAIGERImpl::run(const std::vector<std::string>& args, mlir::MLIRContext &context,
-                         mlir::ModuleOp inputModule, mlir::OwningOpRef<mlir::ModuleOp>& outputModule) {
+bool WriteAIGERImpl::run(const std::vector<std::string>& args, mlir::MLIRContext &context, mlir::ModuleOp inputModule) {
+    if (!inputModule) {
+        return true;
+    }    
+
     WriteImplOptions opts;
     if (!parseOptions(args, opts)) {
         log("[write_aiger]: parser options failed\n\n");
@@ -23,7 +26,7 @@ bool WriteAIGERImpl::run(const std::vector<std::string>& args, mlir::MLIRContext
     std::string errorMessage;
     outputFile.emplace(mlir::openOutputFile(opts.outputFilename, &errorMessage));
     if (!outputFile.value()) {
-        llvm::errs() << errorMessage << "\n";
+        log("[write_aiger]: open output file failed[%s]\n\n", errorMessage.c_str());
         return false;
     }
 

--- a/libs/Write/aiger/aiger.h
+++ b/libs/Write/aiger/aiger.h
@@ -7,8 +7,7 @@ XUANSONG_NAMESPACE_HEADER_START
 
 class WriteAIGERImpl final : public WriteBase {
 public:
-    static bool run(const std::vector<std::string>& args, mlir::MLIRContext& context,
-                    mlir::ModuleOp inputModule, mlir::OwningOpRef<mlir::ModuleOp>& outputModule);
+    static bool run(const std::vector<std::string>& args, mlir::MLIRContext& context, mlir::ModuleOp inputModule);
 
 private:
     WriteAIGERImpl() = default;

--- a/libs/Write/btor2/btor2.cpp
+++ b/libs/Write/btor2/btor2.cpp
@@ -9,11 +9,14 @@
 
 XUANSONG_NAMESPACE_HEADER_START
 
-bool WriteBTOR2Impl::run(const std::vector<std::string>& args, mlir::MLIRContext &context,
-                         mlir::ModuleOp inputModule, mlir::OwningOpRef<mlir::ModuleOp>& outputModule) {
+bool WriteBTOR2Impl::run(const std::vector<std::string>& args, mlir::MLIRContext &context, mlir::ModuleOp inputModule) {
+    if (!inputModule) {
+        return true;
+    }
+
     WriteImplOptions opts;
     if (!parseOptions(args, opts)) {
-        log("[write_btor]: parser options failed\n\n");
+        log("[write_btor2]: parser options failed\n\n");
         return false;
     }
 
@@ -21,14 +24,14 @@ bool WriteBTOR2Impl::run(const std::vector<std::string>& args, mlir::MLIRContext
     std::string errorMessage;
     outputFile.emplace(mlir::openOutputFile(opts.outputFilename, &errorMessage));
     if (!outputFile.value()) {
-        llvm::errs() << errorMessage << "\n";
+        log("[write_btor2]: open output file failed[%s]\n\n", errorMessage.c_str());
         return false;
     }
     
     mlir::PassManager pm(&context);
     pm.addPass(circt::createConvertHWToBTOR2Pass(outputFile.value()->os()));
     if (failed(pm.run(inputModule))) {
-        log("[write_btor]: run PassManager failed\n\n");
+        log("[write_btor2]: run PassManager failed\n\n");
         return false;
     }
 

--- a/libs/Write/btor2/btor2.h
+++ b/libs/Write/btor2/btor2.h
@@ -7,8 +7,7 @@ XUANSONG_NAMESPACE_HEADER_START
 
 class WriteBTOR2Impl final: public WriteBase {
 public:
-    static bool run(const std::vector<std::string>&args, mlir::MLIRContext& context,
-                    mlir::ModuleOp inputModule, mlir::OwningOpRef<mlir::ModuleOp>& outputModule);
+    static bool run(const std::vector<std::string>&args, mlir::MLIRContext& context, mlir::ModuleOp inputModule);
 
 private:
     WriteBTOR2Impl() = default;

--- a/libs/Write/mlir/mlir.cpp
+++ b/libs/Write/mlir/mlir.cpp
@@ -5,23 +5,23 @@
 
 XUANSONG_NAMESPACE_HEADER_START
 
-bool WriteMLIRImpl::run(const std::vector<std::string>& args, mlir::MLIRContext& context,
-                        mlir::ModuleOp inputModule, mlir::OwningOpRef<mlir::ModuleOp>& outputModule) {
-    WriteImplOptions opts;
-    if (!parseOptions(args, opts)) {
-        log("write_mlir]: parse options failed\n\n");
-        return false;
-    }
-
+bool WriteMLIRImpl::run(const std::vector<std::string>& args, mlir::MLIRContext& context, mlir::ModuleOp inputModule) {
+    // inputModule is empty
     if (!inputModule) {
         return true;
+    }
+
+    WriteImplOptions opts;
+    if (!parseOptions(args, opts)) {
+        log("[write_mlir]: parse options failed\n\n");
+        return false;
     }
 
     std::optional<std::unique_ptr<llvm::ToolOutputFile>> outputFile;
     std::string errorMessage;
     outputFile.emplace(mlir::openOutputFile(opts.outputFilename, &errorMessage));
     if (!outputFile.value()) {
-        llvm::errs() << errorMessage << "\n";
+        log("[write_mlir]: open output file failed[%s]\n\n", errorMessage.c_str());
         return false;
     }
 

--- a/libs/Write/mlir/mlir.h
+++ b/libs/Write/mlir/mlir.h
@@ -7,12 +7,10 @@ XUANSONG_NAMESPACE_HEADER_START
 
 class WriteMLIRImpl final : public WriteBase {
 public:
-    WriteMLIRImpl() = default;
+    static bool run(const std::vector<std::string>& args, mlir::MLIRContext& context, mlir::ModuleOp inputModule);
 
-public:
-    static bool run(const std::vector<std::string>& args,
-                    mlir::MLIRContext& context, mlir::ModuleOp inputModule,
-                    mlir::OwningOpRef<mlir::ModuleOp>& outputModule);
+private:
+    WriteMLIRImpl() = default;
 };
 
 XUANSONG_NAMESPACE_HEADER_END

--- a/libs/Write/smt/smt.cpp
+++ b/libs/Write/smt/smt.cpp
@@ -9,8 +9,11 @@
 
 XUANSONG_NAMESPACE_HEADER_START
 
-bool WriteSMTImpl::run(const std::vector<std::string>& args, mlir::MLIRContext &context,
-                       mlir::ModuleOp inputModule, mlir::OwningOpRef<mlir::ModuleOp>& outputModule) {
+bool WriteSMTImpl::run(const std::vector<std::string>& args, mlir::MLIRContext &context, mlir::ModuleOp inputModule) {
+    if (!inputModule) {
+        return true;
+    }    
+
     WriteImplOptions opts;
     if (!parseOptions(args, opts)) {
         log("[write_smt]: parse options failed\n\n");
@@ -21,12 +24,12 @@ bool WriteSMTImpl::run(const std::vector<std::string>& args, mlir::MLIRContext &
     std::string errorMessage;
     outputFile.emplace(mlir::openOutputFile(opts.outputFilename, &errorMessage));
     if (!outputFile.value()) {
-        llvm::errs() << errorMessage << "\n";
+        log("[write_smt]: open output file failed[%s]\n\n", errorMessage.c_str());
         return false;
     }
     
     if (failed(mlir::smt::exportSMTLIB(inputModule, outputFile.value()->os()))) {
-        log("write_smt]: exportSMTLIB failed\n\n");
+        log("[write_smt]: exportSMTLIB failed\n\n");
         return false;
     }
 

--- a/libs/Write/smt/smt.h
+++ b/libs/Write/smt/smt.h
@@ -7,8 +7,7 @@ XUANSONG_NAMESPACE_HEADER_START
 
 class WriteSMTImpl final : public WriteBase {
 public:
-    static bool run(const std::vector<std::string>& args, mlir::MLIRContext& context,
-                    mlir::ModuleOp inputModule, mlir::OwningOpRef<mlir::ModuleOp>& outputModule);
+    static bool run(const std::vector<std::string>& args, mlir::MLIRContext& context, mlir::ModuleOp inputModule);
 
 private:
     WriteSMTImpl() = default;


### PR DESCRIPTION
【需求编号】
US-013

【需求描述】
修复write_command清除了全局的moduleOp的问题

【一句话总结实现】
WriteXXXImpl::run()去除outputModule的参数

【实现细节】
1. WriteXXXImpl::run()去除outputModule的参数
2. WriteXXXImpl::run()判断inputModule是否为空

【自测结果】
本地编译，cases均成功
