### PR TITLE
[Backend][US-015] 1. exportAIGER change options from aag to aiger 2. process filename include "~/"

### DIFF
--- a/client/CMakeLists.txt
+++ b/client/CMakeLists.txt
@@ -2,4 +2,8 @@ aux_source_directory(${CMAKE_CURRENT_SOURCE_DIR} SRC_FILES)
 add_executable(equiv_fusion ${SRC_FILES})
 
 target_include_directories(equiv_fusion PRIVATE ${INCLUDE_DIRS})
-target_link_libraries(equiv_fusion PUBLIC utils)
+target_link_libraries(equiv_fusion
+    PUBLIC
+    utils
+    -Wl,--whole-archive base -Wl,--no-whole-archive
+)

--- a/infrastructure/utils/CMakeLists.txt
+++ b/infrastructure/utils/CMakeLists.txt
@@ -1,6 +1,10 @@
 aux_source_directory(${CMAKE_CURRENT_SOURCE_DIR} SRC_FILES)
+aux_source_directory(${CMAKE_CURRENT_SOURCE_DIR}/path PATH_UTIL_FILES)
 
-add_library(utils STATIC ${SRC_FILES})
+add_library(utils STATIC
+    ${SRC_FILES}
+    ${PATH_UTIL_FILES}
+)
 
 target_include_directories(utils PRIVATE ${INCLUDE_DIRS})
 target_include_directories(utils PRIVATE ${READLINE_INCLUDE_DIRECTORY})
@@ -9,7 +13,6 @@ target_link_libraries(utils
     PUBLIC
     ${READLINE_LIBRARY}
     log                         # 显式链接log库
-    -Wl,--whole-archive base -Wl,--no-whole-archive
 )
 
 

--- a/infrastructure/utils/path/path.cpp
+++ b/infrastructure/utils/path/path.cpp
@@ -1,0 +1,12 @@
+#include "infrastructure/utils/path/path.h"
+
+namespace XuanSong {
+namespace PathUtil {
+
+void expandTilde(std::string& path) {
+    if (path.compare(0, 2, "~/") == 0)
+        path = path.replace(0, 1, getenv("HOME"));
+}
+
+} // namespace PathUtil
+} // namespace XuanSong

--- a/infrastructure/utils/path/path.h
+++ b/infrastructure/utils/path/path.h
@@ -1,0 +1,16 @@
+#ifndef EQUIVFUSION_UTILS_PATH_H
+#define EQUIVFUSION_UTILS_PATH_H
+
+#include <string>
+#include <stdlib.h>
+
+namespace XuanSong {
+namespace PathUtil {
+
+void expandTilde(std::string& path);
+
+} // namespace PathUtil
+} // namespace XuanSong
+
+
+#endif // EQUIVFUSION_UTILS_PATH_H

--- a/libs/Tools/EquivMiter/CMakeLists.txt
+++ b/libs/Tools/EquivMiter/CMakeLists.txt
@@ -21,7 +21,7 @@ target_link_libraries(EquivFusionToolEquivMiter
     CIRCTArcTransforms
     CIRCTHWToBTOR2    
 
-    log
+    utils
 )
 
 llvm_update_compile_flags(EquivFusionToolEquivMiter)

--- a/libs/Tools/EquivMiter/equiv_miter.cpp
+++ b/libs/Tools/EquivMiter/equiv_miter.cpp
@@ -1,4 +1,5 @@
 #include "infrastructure/log/log.h"
+#include "infrastructure/utils/path/path.h"
 #include "libs/Tools/EquivMiter/equiv_miter.h"
 
 #include "circt/Dialect/HW/HWOps.h"
@@ -106,7 +107,8 @@ llvm::LogicalResult EquivMiterTool::miterToAIGER(mlir::PassManager& pm, mlir::Mo
     if (ops.empty() || std::next(ops.begin()) != ops.end())
         return failure();
 
-    return aiger::exportAIGER(*ops.begin(), os);
+    circt::aiger::ExportAIGEROptions exportAIGEROpts = {true, true};
+    return aiger::exportAIGER(*ops.begin(), os, &exportAIGEROpts);
 }
 
 LogicalResult EquivMiterTool::miterToBTOR2(mlir::PassManager& pm, mlir::ModuleOp module, llvm::raw_ostream& os,
@@ -131,6 +133,7 @@ bool EquivMiterTool::parseOptions(const std::vector<std::string> &args, EquivMit
             opts.secondModuleName = args[++idx];
         } else if (arg == "-o" && idx + 1 < args.size()) {
             opts.outputFilename = args[++idx];
+            PathUtil::expandTilde(opts.outputFilename);
         } else if (arg == "-mitermode" && idx + 1 < args.size()) {
             auto val = args[++idx];
             if (val == "aiger") {

--- a/libs/Write/CMakeLists.txt
+++ b/libs/Write/CMakeLists.txt
@@ -19,6 +19,6 @@ target_link_libraries(EquivFusionWrite
     CIRCTExportAIGER 
     CIRCTHWToBTOR2
 
-    log
+    utils
 )
 

--- a/libs/Write/aiger/aiger.cpp
+++ b/libs/Write/aiger/aiger.cpp
@@ -34,7 +34,8 @@ bool WriteAIGERImpl::run(const std::vector<std::string>& args, mlir::MLIRContext
     if (ops.empty() || std::next(ops.begin()) != ops.end())
         return false;
 
-    if (failed(circt::aiger::exportAIGER(*ops.begin(), outputFile.value()->os()))) {
+    circt::aiger::ExportAIGEROptions exportAIGEROpts = {true, true};
+    if (failed(circt::aiger::exportAIGER(*ops.begin(), outputFile.value()->os(), &exportAIGEROpts))) {
         log("[write_aiger]: run exportAIGER failed\n\n");
         return false;
     }

--- a/libs/Write/base/base.cpp
+++ b/libs/Write/base/base.cpp
@@ -1,3 +1,4 @@
+#include "infrastructure/utils/path/path.h"
 #include "libs/Write/base/base.h"
 
 XUANSONG_NAMESPACE_HEADER_START
@@ -14,6 +15,7 @@ bool WriteBase::parseOptions(const std::vector<std::string>& args, WriteImplOpti
     for (size_t idx = 0; idx < args.size(); idx++) {
         auto arg = args[idx];
         opts.outputFilename = arg;
+        PathUtil::expandTilde(opts.outputFilename);
     }
     return true;
 }


### PR DESCRIPTION
【需求编号】
US-015

【需求描述】
1. exportAIGER change options from aag to aiger
2. process filename include "~/"

【一句话总结实现】
exportAIGER调用处修改参数；实现expandTilde，处理文件名处调用expandTilde。

【实现细节】
1. WriteAIGERImpl::run()/EquivMiterTool::miterToAIGER()修改调用exportAIGER的参数。
2. infrastructure/utils/path中实现expandTilde()， WriteBase::parseOptions()/EquivMiterTool::parseOptions()调用expandTilde()。

【自测结果】
本地编译，cases均成功