### PR TITLE
[Frontend][US-018]: Flatten multi-dimensional memref to 1-dimensional

### DIFF
--- a/infrastructure/base/CMakeLists.txt
+++ b/infrastructure/base/CMakeLists.txt
@@ -21,8 +21,6 @@ target_link_libraries(base
     MLIRLLVMDialect
     MLIROptLib
     MLIRTransforms
-    MLIRSCFToControlFlow
-    MLIRAffineToStandard
 
     LLVMSupport
 
@@ -44,7 +42,6 @@ target_link_libraries(base
     EquivFusionSolverRunner
     EquivFusionToolEquivMiter
     EquivFusionWrite 
-    FuncToHWModule
     EquivFusionRemoveRedundantFunc
     EquivFusionConvertCaseToLogicalComparison
     EquivFusionMemrefHLS

--- a/infrastructure/utils/CMakeLists.txt
+++ b/infrastructure/utils/CMakeLists.txt
@@ -1,12 +1,29 @@
 aux_source_directory(${CMAKE_CURRENT_SOURCE_DIR}/log-util LOG_UTIL_FILES)
 aux_source_directory(${CMAKE_CURRENT_SOURCE_DIR}/path-util PATH_UTIL_FILES)
 aux_source_directory(${CMAKE_CURRENT_SOURCE_DIR}/string-util STRING_UTIL_FILES)
+aux_source_directory(${CMAKE_CURRENT_SOURCE_DIR}/hls-util HLS_UTIL_FILES)
 
 add_library(EquivFusionUtils STATIC
     ${LOG_UTIL_FILES}
     ${PATH_UTIL_FILES}
     ${STRING_UTIL_FILES}
+    ${HLS_UTIL_FILES}
 )
 
+target_link_libraries(EquivFusionUtils
+    PUBLIC
+    CIRCTTransforms
 
+    MLIRIR
+    MLIRFuncDialect
+    MLIRTransforms
+    MLIRAffineTransforms
+    MLIRSCFToControlFlow
+    MLIRAffineToStandard
+    MLIRAffineAnalysis
+
+    FuncToHWModule
+    EquivFusionRemoveRedundantFunc
+    EquivFusionMemrefHLS
+)
 

--- a/infrastructure/utils/hls-util/populate_hls_passes.cpp
+++ b/infrastructure/utils/hls-util/populate_hls_passes.cpp
@@ -1,0 +1,65 @@
+#include "infrastructure/utils/hls-util/populate_hls_passes.h"
+
+#include "mlir/Transforms/Passes.h"
+#include "mlir/Conversion/Passes.h"
+#include "mlir/Dialect/Affine/Passes.h"
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/Dialect/Affine/Analysis/LoopAnalysis.h"
+
+#include "circt/Conversion/Passes.h"
+#include "circt/Dialect/Seq/SeqDialect.h"
+#include "circt/Dialect/Seq/SeqPasses.h"
+#include "circt/Transforms/Passes.h"
+
+
+#include "circt-passes/FuncToHWModule/Passes.h"
+#include "circt-passes/RemoveRedundantFunc/Passes.h"
+#include "circt-passes/MemrefHLS/Passes.h"
+
+XUANSONG_NAMESPACE_HEADER_START
+
+void populateHLSPasses(mlir::PassManager &pm) {
+    // Unroll affine loops.
+    pm.addPass(mlir::createCanonicalizerPass());
+    pm.addNestedPass<mlir::func::FuncOp>(mlir::affine::createLoopUnrollPass(-1, false, true, [](mlir::affine::AffineForOp forOp) -> unsigned int {
+        std::optional<uint64_t> mayBeConstantTripCount = mlir::affine::getConstantTripCount(forOp);
+        if (mayBeConstantTripCount) {
+            return *mayBeConstantTripCount;
+        }
+        return 0;
+    }));
+    
+    // Replace affine memref accesses by scalars by forwarding stores to loads and eliminating redundant loads.
+    pm.addPass(mlir::createCanonicalizerPass());
+    pm.addNestedPass<mlir::func::FuncOp>(mlir::affine::createAffineScalarReplacementPass());
+
+    // Lower affine to a conbination of Arith and
+    pm.addPass(mlir::createCanonicalizerPass());
+    pm.addPass(mlir::createLowerAffinePass());
+
+    // Convert multi-dimensional memref to one-dimensional memref.
+    pm.addPass(mlir::createCanonicalizerPass());
+    pm.addPass(circt::createFlattenMemRefPass());
+    pm.addPass(circt::createFlattenMemRefCallsPass());
+
+    pm.enableVerifier(false);
+    // Convert all index typed values to an i32 integer.
+    pm.addPass(mlir::createCanonicalizerPass());
+    pm.addNestedPass<mlir::func::FuncOp>(circt::createEquivFusionConvertIndexToI32Pass());
+
+    // Lower Scf to ControlFlow dialect.
+    pm.addPass(mlir::createCanonicalizerPass());
+    pm.addPass(mlir::createSCFToControlFlowPass());
+
+    // Convert Arith to Comb
+    pm.addPass(mlir::createCanonicalizerPass());
+    pm.addPass(circt::createMapArithToCombPass());
+
+    //Convert Func to Module
+    pm.addPass(mlir::createCanonicalizerPass());
+    pm.addPass(circt::createFuncToHWModule());
+    
+    pm.addPass(mlir::createCanonicalizerPass());
+}
+
+XUANSONG_NAMESPACE_HEADER_END

--- a/infrastructure/utils/hls-util/populate_hls_passes.h
+++ b/infrastructure/utils/hls-util/populate_hls_passes.h
@@ -1,0 +1,8 @@
+#include "infrastructure/utils/namespace_macro.h"
+#include "mlir/Pass/PassManager.h"
+
+XUANSONG_NAMESPACE_HEADER_START
+
+void populateHLSPasses(mlir::PassManager &pm);
+
+XUANSONG_NAMESPACE_HEADER_END

--- a/test/integration_tests/cases/multiple_dimensional_test/multiple_dimensional_test.mlir
+++ b/test/integration_tests/cases/multiple_dimensional_test/multiple_dimensional_test.mlir
@@ -1,0 +1,17 @@
+module {
+  func.func @test(%arg0: memref<2x2xi32> {polygeist.param_name = "data"}) -> i32 attributes {llvm.linkage = #llvm.linkage<external>} {
+    %c0_i32 = arith.constant 0 : i32
+    %alloca = memref.alloca() : memref<i32>
+    affine.store %c0_i32, %alloca[] : memref<i32>
+    affine.for %arg1 = 0 to 2 {
+      affine.for %arg2 = 0 to 2 {
+        %1 = affine.load %alloca[] : memref<i32>
+        %2 = affine.load %arg0[%arg1, %arg2] : memref<2x2xi32>
+        %3 = arith.addi %1, %2 : i32
+        affine.store %3, %alloca[] : memref<i32>
+      }
+    }
+    %0 = affine.load %alloca[] : memref<i32>
+    return %0 : i32
+  }
+}

--- a/test/integration_tests/cases/multiple_dimensional_test/multiple_dimensional_test.sh
+++ b/test/integration_tests/cases/multiple_dimensional_test/multiple_dimensional_test.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/bash
+
+set -euo pipefail
+
+CASE_DIR=$(dirname "$(realpath "$0")")
+OUTPUT_DIR=${CASE_LOG_PATH:-.}
+
+equiv_fusion -p "read_c -spec -top test multiple_dimensional_test.mlir" \
+             -p "read_c -impl -top test multiple_dimensional_test.mlir" \
+             -p "equiv_miter -specModule test -implModule test -mitermode aiger -o $OUTPUT_DIR/miter.aiger"
+
+aigtocnf "$OUTPUT_DIR/miter.aiger" "$OUTPUT_DIR/miter.cnf"
+
+#CHECK: UNSATISFIABLE
+equiv_fusion -p "solver_runner --solver kissat --inputfile $OUTPUT_DIR/miter.cnf"
+

--- a/tools/equivfusion-hls/CMakeLists.txt
+++ b/tools/equivfusion-hls/CMakeLists.txt
@@ -6,10 +6,8 @@ target_link_libraries(equivfusion-hls
   PRIVATE
 
   CIRCTHW
-  CIRCTHWTransforms
   CIRCTSeq
-  CIRCTSeqTransforms
-  CIRCTTransforms
+  CIRCTComb
 
   MLIRIR
   MLIRLLVMDialect
@@ -19,11 +17,8 @@ target_link_libraries(equivfusion-hls
   MLIRControlFlowDialect
   MLIRSupport
   MLIRTransforms
-  MLIRSCFToControlFlow
-  MLIRAffineToStandard
-  MLIRAffineTransforms
 
-  FuncToHWModule
+  EquivFusionUtils
   EquivFusionRemoveRedundantFunc
   EquivFusionMemrefHLS
 )


### PR DESCRIPTION
【需求编号】
US-018

【需求描述】
在EquivFsionHLS中支持多维memref的处理

【一句话总结实现】
将多维的memref展平成一维的memref

【实现细节】
调用circt中的flatten-memrefpass，将多维的memref展平成一维memref

【自测结果】
增加integration_test/cases/multiple_dimension_test，测试可以将多维memref展平成一维的memref