### PR TITLE
[Miter][US-020] Support Structure in equiv_miter

### DIFF
--- a/include/circt-passes/HWTransforms/Passes.td
+++ b/include/circt-passes/HWTransforms/Passes.td
@@ -40,4 +40,47 @@ def EquivFusionFlattenArraySlice : Pass<"EquivFusion_flatten-array-slice", "mlir
     let dependentDialects = ["circt::hw::HWDialect"];
 }
 
+def EquivFusionHWAggregateToComb : Pass<"EquivFusion-hw-aggregate-to-comb", "mlir::ModuleOp"> {
+    let summary = "Lower aggregate operations to comb operations";
+
+    let description = [{
+        This Pass lower aggregate operations to comb operations
+
+        ```mlir
+        %b = hw.struct_extract %0["b"] : !hw.struct<a: i32, b: i32>
+        ```
+
+        becomes:
+
+        ```mlir
+        %1 = hw.bitcast %0 : (!hw.struct<a: i32, b: i32>) -> i64
+        %2 = comb.extract %1 from 32 : (i64) -> i32
+        ```
+    }];
+
+    let dependentDialects = ["circt::comb::CombDialect"];
+}
+
+def EquivFusionFlattenStructExplode : Pass<"EquivFusion-flatten-struct-explode", "mlir::ModuleOp"> {
+    let summary = "Flatten hw.struct_explode to hw.struct_extract";
+
+
+    let description = [{
+        This Pass flatten hw.struct_explode to hw.struct_extract
+
+        ```mlir
+        %a, %b = hw.struct_explode %0 : !hw.struct<a: i32, b: i32>
+        ```
+
+        becomes:
+
+        ```mlir
+        %a = hw.struct_extract %0["a"] : !hw.struct<a: i32, b: i32>
+        %b = hw.struct_extract %0["b"] : !hw.struct<a: i32, b: i32>
+        ```
+    }];
+
+    let dependentDialects = ["circt::hw::HWDialect"];
+}
+
 #endif // EQUIVFUSION_HW_TRANSFORMS_PASSES_TD

--- a/infrastructure/circt-passes/HWTransforms/CMakeLists.txt
+++ b/infrastructure/circt-passes/HWTransforms/CMakeLists.txt
@@ -1,6 +1,8 @@
 add_circt_library(EquivFusionPassHWTransforms
     flatten_io_array.cpp
     flatten_array_slice.cpp
+    flatten_struct_explode.cpp
+    hw_aggregate_to_comb.cpp
 
     DEPENDS
     EquivFusionPassHWTransformsIncGen

--- a/infrastructure/circt-passes/HWTransforms/flatten_struct_explode.cpp
+++ b/infrastructure/circt-passes/HWTransforms/flatten_struct_explode.cpp
@@ -1,0 +1,52 @@
+#include "circt-passes/HWTransforms/Passes.h"
+#include "circt/Dialect/HW/HWOps.h"
+#include "circt/Dialect/Comb/CombOps.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+
+namespace circt {
+namespace equivfusion {
+namespace hw {
+#define GEN_PASS_DEF_EQUIVFUSIONFLATTENSTRUCTEXPLODE
+#include "circt-passes/HWTransforms/Passes.h.inc"
+} // namespece hw
+} // namespace equivfusion
+} // namespace circt
+
+using namespace circt;
+
+namespace {
+struct StructExplodeOpConversion : OpRewritePattern<hw::StructExplodeOp> {
+    using OpRewritePattern<hw::StructExplodeOp>::OpRewritePattern;
+
+    LogicalResult matchAndRewrite(hw::StructExplodeOp op, PatternRewriter &rewriter) const override {
+        auto opResults = op.getResults();
+        auto elements = type_cast<hw::StructType>(op.getInput().getType()).getElements();
+        assert(opResults.size() == elements.size());
+
+        SmallVector<Value> newResults;
+        newResults.reserve(opResults.size());
+        for (uint32_t index = 0; index < elements.size(); index++) {
+            auto extractOp = hw::StructExtractOp::create(rewriter,
+                                                         op.getLoc(), op.getInput(), elements[index].name);
+            rewriter.replaceAllUsesWith(opResults[index], extractOp);
+        }
+        return success();
+    }
+};
+} // namespace
+
+namespace {
+struct EquivFusionFlattenStructExplodePass
+        : public circt::equivfusion::hw::impl::EquivFusionFlattenStructExplodeBase<EquivFusionFlattenStructExplodePass> {
+    void runOnOperation() override;
+};
+} // namespace
+
+void EquivFusionFlattenStructExplodePass::runOnOperation() {
+    RewritePatternSet patterns(&getContext());
+    patterns.add<StructExplodeOpConversion>(patterns.getContext());
+    mlir::FrozenRewritePatternSet frozen(std::move(patterns));
+
+    if (failed(mlir::applyPatternsGreedily(getOperation(), frozen)))
+        return signalPassFailure();
+}

--- a/infrastructure/circt-passes/HWTransforms/hw_aggregate_to_comb.cpp
+++ b/infrastructure/circt-passes/HWTransforms/hw_aggregate_to_comb.cpp
@@ -1,0 +1,106 @@
+#include "circt-passes/HWTransforms/Passes.h"
+#include "circt/Dialect/HW/HWDialect.h"
+#include "circt/Dialect/HW/HWOps.h"
+#include "circt/Dialect/Comb/CombOps.h"
+#include "mlir/Transforms/DialectConversion.h"
+
+namespace circt {
+namespace equivfusion {
+namespace hw {
+#define GEN_PASS_DEF_EQUIVFUSIONHWAGGREGATETOCOMB
+#include "circt-passes/HWTransforms/Passes.h.inc"
+} // namespace hw
+} // namespace equivfusion
+} // namespace circt
+
+using namespace mlir;
+using namespace circt;
+
+namespace {
+
+struct HWStructExtractOpConversion
+        : OpConversionPattern<hw::StructExtractOp> {
+    using OpConversionPattern<hw::StructExtractOp>::OpConversionPattern;
+
+    LogicalResult
+    matchAndRewrite(hw::StructExtractOp op, OpAdaptor adaptor,
+                    ConversionPatternRewriter &rewriter) const override {
+        auto structType = cast < hw::StructType > (op.getInput().getType());
+        auto fieldName = op.getFieldName();
+
+        uint64_t offset = 0;
+        for (const auto &field: structType.getElements()) {
+            if (field.name == fieldName) {
+                break;
+            }
+            offset += hw::getBitWidth(field.type);
+        }
+
+        auto fieldWidth = hw::getBitWidth(op.getResult().getType());
+        auto extracted = rewriter.createOrFold<comb::ExtractOp>(op.getLoc(), adaptor.getInput(), offset,
+                                                                fieldWidth);
+
+        rewriter.replaceOp(op, extracted);
+        return success();
+    }
+};
+
+class AggregateTypeConverter : public TypeConverter {
+public:
+    AggregateTypeConverter() {
+        addConversion([](Type type) -> Type { return type; });
+        addConversion([](hw::StructType t) -> Type {
+            return IntegerType::get(t.getContext(), hw::getBitWidth(t));
+        });
+        addTargetMaterialization([](mlir::OpBuilder &builder, mlir::Type resultType,
+                                    mlir::ValueRange inputs,
+                                    mlir::Location loc) -> mlir::Value {
+            if (inputs.size() != 1)
+                return Value();
+
+            return hw::BitcastOp::create(builder, loc, resultType, inputs[0])
+                    ->getResult(0);
+        });
+
+        addSourceMaterialization([](mlir::OpBuilder &builder, mlir::Type resultType,
+                                    mlir::ValueRange inputs,
+                                    mlir::Location loc) -> mlir::Value {
+            if (inputs.size() != 1)
+                return Value();
+
+            return hw::BitcastOp::create(builder, loc, resultType, inputs[0])
+                    ->getResult(0);
+        });
+    }
+};
+
+} // namespace
+
+static void populateHWAggregateToCombOpConversionPatterns(
+        RewritePatternSet &patterns, AggregateTypeConverter &typeConverter) {
+    patterns.add<HWStructExtractOpConversion>(
+            typeConverter, patterns.getContext());
+}
+
+namespace {
+struct EquivFusionHWAggregateToCombPass
+        : public circt::equivfusion::hw::impl::EquivFusionHWAggregateToCombBase<EquivFusionHWAggregateToCombPass> {
+    void runOnOperation() override;
+};
+} // namespace
+
+void EquivFusionHWAggregateToCombPass::runOnOperation() {
+    ConversionTarget target(getContext());
+
+    target.addIllegalOp<hw::StructExtractOp>();
+
+    target.addLegalDialect<hw::HWDialect, comb::CombDialect>();
+
+    RewritePatternSet patterns(&getContext());
+    AggregateTypeConverter typeConverter;
+    populateHWAggregateToCombOpConversionPatterns(patterns, typeConverter);
+
+    if (failed(mlir::applyPartialConversion(getOperation(), target,
+                                            std::move(patterns))))
+        return signalPassFailure();
+}

--- a/libs/Tools/EquivMiter/equiv_miter.cpp
+++ b/libs/Tools/EquivMiter/equiv_miter.cpp
@@ -163,12 +163,24 @@ void EquivMiterTool::populatePreparePasses(mlir::PassManager& pm) {
 
     /// Inlines Private HW modules
     pm.addPass(hw::createFlattenModules());
-    /// [Temp fix]: hw.arary_slice unsupported in HWAggregateToComb, replace with hw.array_get + hw.array_create
-    pm.addPass(circt::equivfusion::hw::createEquivFusionFlattenArraySlice());
+
+    /// Flatten IO struct
+    pm.addPass(circt::hw::createFlattenIO());
+    pm.addPass(createSimpleCanonicalizerPass());
+
     /// Module Port array => integer
     pm.addPass(circt::equivfusion::hw::createEquivFusionFlattenIOArray());
+
+    /// [Temp fix]: hw.arary_slice unsupported in HWAggregateToComb, replace with hw.array_get + hw.array_create
+    pm.addPass(circt::equivfusion::hw::createEquivFusionFlattenArraySlice());
+    /// [Temp fix]: hw.struct_explode replace with hw.struct_extract
+    pm.addPass(circt::equivfusion::hw::createEquivFusionFlattenStructExplode());
+
     /// Aggregate Operations tp Comb operations
     pm.nest<hw::HWModuleOp>().addPass(hw::createHWAggregateToComb());
+    /// [Temp fix]: Struct op to Comb
+    pm.addPass(circt::equivfusion::hw::createEquivFusionHWAggregateToComb());
+
     /// Canonicalize
     pm.addPass(createSimpleCanonicalizerPass());
 }

--- a/test/integration_tests/cases/structure_rtl2rtl/structure_always.sv
+++ b/test/integration_tests/cases/structure_rtl2rtl/structure_always.sv
@@ -1,0 +1,26 @@
+typedef struct packed {int a; int b;} StructType;
+
+module structure(
+    input int in_int,
+    input StructType in_struct,
+    output StructType out_struct_1,
+    output StructType out_struct_2,
+    output StructType out_struct_3,
+    output StructType out_struct_4,
+    output int out_int,
+    output StructType out_struct_5
+);
+    always_comb begin
+        out_struct_1 = in_struct;
+
+        out_struct_2 = {32'b0, 32'b1};
+        out_struct_3 = '{32'b0, 32'b1};
+
+        out_struct_4 = '{in_int, in_int};           // hw.struct_create
+
+        out_int = in_struct.a;                      // hw.struct_extract
+
+        out_struct_5.a = in_int;                    // hw.bitcast + hw.struct_create + hw.struct_extract
+        out_struct_5.b = in_int;
+    end
+endmodule

--- a/test/integration_tests/cases/structure_rtl2rtl/structure_assign.sv
+++ b/test/integration_tests/cases/structure_rtl2rtl/structure_assign.sv
@@ -1,0 +1,25 @@
+typedef struct packed {int a; int b;} StructType;
+
+module structure(
+    input int in_int,
+    input StructType in_struct,
+    output StructType out_struct_1,
+    output StructType out_struct_2,
+    output StructType out_struct_3,
+    output StructType out_struct_4,
+    output int out_int,
+    output StructType out_struct_5
+);
+    assign out_struct_1 = in_struct;
+
+    assign out_struct_2 = {32'b0, 32'b1};
+    assign out_struct_3 = '{32'b0, 32'b1};
+
+    assign out_struct_4 = '{in_int, in_int};           // hw.struct_create
+
+    assign out_int = in_struct.a;                      // hw.struct_extract
+
+    assign out_struct_5.a = in_int;                    // hw.bitcast + hw.struct_create + hw.struct_extract
+    assign out_struct_5.b = in_int;
+
+endmodule

--- a/test/integration_tests/cases/structure_rtl2rtl/structure_rtl2rtl.sh
+++ b/test/integration_tests/cases/structure_rtl2rtl/structure_rtl2rtl.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/bash
+
+set -euo pipefail
+
+CASE_DIR=$(dirname "$(realpath "$0")")
+OUTPUT_DIR=${CASE_LOG_PATH:-.}
+
+#CHECK: unsat
+equiv_fusion -p "read_v -spec -top structure structure_assign.sv" \
+             -p "read_v -impl -top structure structure_always.sv" \
+             -p "equiv_miter -specModule structure -implModule structure -mitermode smtlib -o $OUTPUT_DIR/miter.smt" \
+             -p "solver_runner --solver z3 --inputfile $OUTPUT_DIR/miter.smt"
+
+#CHECK: unsat
+equiv_fusion -p "read_v -spec -top structure structure_assign.sv" \
+             -p "read_v -impl -top structure structure_always.sv" \
+             -p "equiv_miter -specModule structure -implModule structure -mitermode btor2 -o $OUTPUT_DIR/miter.btor2" \
+             -p "solver_runner --solver bitwuzla --inputfile $OUTPUT_DIR/miter.btor2"
+
+
+#CHECK: UNSATISFIABLE
+equiv_fusion -p "read_v -spec -top structure structure_assign.sv" \
+             -p "read_v -impl -top structure structure_always.sv" \
+             -p "equiv_miter -specModule structure -implModule structure -mitermode aiger -o $OUTPUT_DIR/miter.aiger"
+aigtocnf "$OUTPUT_DIR/miter.aiger" "$OUTPUT_DIR/miter.cnf"
+equiv_fusion -p "solver_runner --solver kissat --inputfile $OUTPUT_DIR/miter.cnf"
+


### PR DESCRIPTION
【需求编号】
US-020

【需求描述】
equiv_miter生成smtlib/aiger/btor2时，支持Port是Structure类型

【一句话总结实现】
Structure Port展平，struct Operations转换成comb operation

【实现细节】
1. 调用FlattenIO：Structure Port展平
2. 实现Pass EquivFusionHWAggregateToComb，并调用，将hw::StructExtracOp转换成comb::ExtractOp
3. 实现Pass EquivFusionFlattenStructExplode，并调用，将hw::StructExplodeOp转换成多个hw::StructExtractOp

