### PR TITLE
[Infrastructure][US-021]: Add tool equivfusion-opt

### DIFF
--- a/include/circt-passes/CombTransforms/Passes.td
+++ b/include/circt-passes/CombTransforms/Passes.td
@@ -3,7 +3,7 @@
 
 include "mlir/Pass/PassBase.td"
 
-def EquivFusionDecomposeConcat : Pass<"EquivFusion-decompose-concat", "::mlir::ModuleOp"> {
+def EquivFusionDecomposeConcat : Pass<"equivfusion-decompose-concat", "::mlir::ModuleOp"> {
   let summary = "Decompose multi-input concat operations into binary concat chains";
   let description = [{
     This pass decomposes comb.concat operations with more than 2 inputs into
@@ -25,7 +25,7 @@ def EquivFusionDecomposeConcat : Pass<"EquivFusion-decompose-concat", "::mlir::M
   let dependentDialects = ["circt::comb::CombDialect"];
 }
 
-def EquivFusionReplicateToConcat : Pass<"EquivFusion-replicate-to-concat", "::mlir::ModuleOp"> {
+def EquivFusionReplicateToConcat : Pass<"equivfusion-replicate-to-concat", "::mlir::ModuleOp"> {
     let summary = "Convert 'comb.replicate' to 'comb.concat'";
 
     let description = [{

--- a/include/circt-passes/FuncToHWModule/CMakeLists.txt
+++ b/include/circt-passes/FuncToHWModule/CMakeLists.txt
@@ -8,4 +8,4 @@ mlir_tablegen(Passes.h.inc -gen-pass-decls -name EquivFusionFuncToHWModule)
 mlir_tablegen(EquivFusionFuncToHWModule.capi.h.inc -gen-pass-capi-header --prefix EquivFusionFuncToHWModule)
 mlir_tablegen(EquivFusionFuncToHWModule.capi.cpp.inc -gen-pass-capi-impl --prefix EquivFusionFuncToHWModule)
 
-add_public_tablegen_target(FuncToHWModuleIncGen)
+add_public_tablegen_target(EquivFusionFuncToHWModuleIncGen)

--- a/include/circt-passes/FuncToHWModule/Passes.h
+++ b/include/circt-passes/FuncToHWModule/Passes.h
@@ -5,7 +5,7 @@
 namespace circt {
 
 /// Generate the code for registering passes.
-#define GEN_PASS_DECL_FUNCTOHWMODULE
+#define GEN_PASS_DECL_EQUIVFUSIONFUNCTOHWMODULE
 #define GEN_PASS_REGISTRATION
 #include "circt-passes/FuncToHWModule/Passes.h.inc"
 

--- a/include/circt-passes/FuncToHWModule/Passes.td
+++ b/include/circt-passes/FuncToHWModule/Passes.td
@@ -3,7 +3,7 @@
 
 include "mlir/Pass/PassBase.td"
 
-def FuncToHWModule : Pass<"func-to-hw-module", "mlir::ModuleOp"> { 
+def EquivFusionFuncToHWModule : Pass<"equivfusion-func-to-hw-module", "mlir::ModuleOp"> {
     let summary = "Convert func.func to hw.module";
 
     let description = [{

--- a/include/circt-passes/HWTransforms/Passes.td
+++ b/include/circt-passes/HWTransforms/Passes.td
@@ -3,7 +3,7 @@
 
 include "mlir/Pass/PassBase.td"
 
-def EquivFusionFlattenIOArray : Pass<"EquivFusion-flatten-io-array", "mlir::ModuleOp"> {
+def EquivFusionFlattenIOArray : Pass<"equivfusion-flatten-io-array", "mlir::ModuleOp"> {
     let summary = "Convert packed-array port of hw.module to integer";
 
     let description = [{
@@ -13,7 +13,7 @@ def EquivFusionFlattenIOArray : Pass<"EquivFusion-flatten-io-array", "mlir::Modu
     let dependentDialects = ["circt::hw::HWDialect"];
 }
 
-def EquivFusionHWAggregateOpsConvert : Pass<"EquivFusion-hw-aggregate-ops-convert", "mlir::ModuleOp"> {
+def EquivFusionHWAggregateOpsConvert : Pass<"equivfusion-hw-aggregate-ops-convert", "mlir::ModuleOp"> {
     let summary = "hw aggregate operations convert";
 
     let description = [{
@@ -27,7 +27,7 @@ def EquivFusionHWAggregateOpsConvert : Pass<"EquivFusion-hw-aggregate-ops-conver
     let dependentDialects = ["circt::hw::HWDialect"];
 }
 
-def EquivFusionHWAggregateToComb : Pass<"EquivFusion-hw-aggregate-to-comb", "mlir::ModuleOp"> {
+def EquivFusionHWAggregateToComb : Pass<"equivfusion-hw-aggregate-to-comb", "mlir::ModuleOp"> {
     let summary = "Lower aggregate operations to comb operations";
 
     let description = [{
@@ -37,7 +37,7 @@ def EquivFusionHWAggregateToComb : Pass<"EquivFusion-hw-aggregate-to-comb", "mli
     let dependentDialects = ["circt::comb::CombDialect"];
 }
 
-def EquivFusionInitPostDefinedOperands : Pass<"EquivFusion-init-post-defined-operands", "mlir::ModuleOp"> {
+def EquivFusionInitPostDefinedOperands : Pass<"equivfusion-init-post-defined-operands", "mlir::ModuleOp"> {
     let summary = "Init post defined operands in ArrayInjectOp/StructInjectOp";
 
     let description = [{

--- a/include/circt-passes/InitAllPasses.h
+++ b/include/circt-passes/InitAllPasses.h
@@ -1,0 +1,27 @@
+#ifndef EQUIVFUSION_INITALLPASSES_H
+#define EQUIVFUSION_INITALLPASSES_H
+
+#include "circt-passes/CombTransforms/Passes.h"
+#include "circt-passes/ConvertCaseToLogicalComparsion/Passes.h"
+#include "circt-passes/FuncToHWModule/Passes.h"
+#include "circt-passes/HWTransforms/Passes.h"
+#include "circt-passes/MemrefHLS/Passes.h"
+#include "circt-passes/Miter/Passes.h"
+#include "circt-passes/RemoveRedundantFunc/Passes.h"
+#include "circt-passes/TemporalUnroll/Passes.h"
+
+namespace circt {
+inline void registerAllEquivFusionPasses() {
+    equivfusion::comb::registerPasses();
+    comb::registerEquivFusionConvertCaseToLogicalComparisonPasses();
+    registerEquivFusionFuncToHWModulePasses();
+    equivfusion::hw::registerPasses();
+    registerEquivFusionMemrefHLSPasses();
+    equivfusion::registerEquivFusionMiterPasses();
+    registerEquivFusionRemoveRedundantFuncPasses();
+    equivfusion::registerEquivFusionTemporalUnrollPasses();
+}
+
+} // namespace circt
+
+#endif //EQUIVFUSION_INITALLPASSES_H

--- a/include/circt-passes/Miter/Passes.td
+++ b/include/circt-passes/Miter/Passes.td
@@ -4,10 +4,10 @@
 include "mlir/Pass/PassBase.td"
 include "mlir/Rewrite/PassUtil.td"
 
-def EquivFusionMiter : Pass<"EquivFusion-miter", "::mlir::ModuleOp"> {
+def EquivFusionMiter : Pass<"equivfusion-equiv-miter", "::mlir::ModuleOp"> {
     let summary = "Lower CIRCTs core dialects to a LEC problem statement";
     let description = [{
-        Taks two `hw.module` operations and lowers them to `smt` or `aiger` or `btor2`.
+        Takes two `hw.module` operations and lowers them to `smt` or `aiger` or `btor2`.
     }];
 
     let options = [
@@ -18,16 +18,16 @@ def EquivFusionMiter : Pass<"EquivFusion-miter", "::mlir::ModuleOp"> {
                /*default=*/"",
                "Name of the second of the two modules to compare.">,
         Option<"miterMode", "miter-mode", "MiterModeEnum",
-              /*default=*/"MiterModeEnum::SMTLIB",
-            "Select what additional code to add.",
-            [{::llvm::cl::values(
-             clEnumValN(MiterModeEnum::SMTLIB,
-             "SMTLIB", "Miter for SMTLIB output."),
-             clEnumValN(MiterModeEnum::AIGER,
-             "AIGER", "Miter for AIGER output."),
-             clEnumValN(MiterModeEnum::BTOR2,
-             "BTOR2", "Miter for BTOR2 output.")
-           )}]>,
+                /*default=*/"MiterModeEnum::SMTLIB",
+                "Select what additional code to add.",
+                [{::llvm::cl::values(
+                 clEnumValN(MiterModeEnum::SMTLIB,
+                 "SMTLIB", "Miter for SMTLIB output."),
+                 clEnumValN(MiterModeEnum::AIGER,
+                 "AIGER", "Miter for AIGER output."),
+                 clEnumValN(MiterModeEnum::BTOR2,
+                 "BTOR2", "Miter for BTOR2 output.")
+               )}]>,
     ];
 
     let dependentDialects = [

--- a/include/circt-passes/TemporalUnroll/Passes.h
+++ b/include/circt-passes/TemporalUnroll/Passes.h
@@ -4,12 +4,14 @@
 #include "mlir/Pass/Pass.h"
 
 namespace circt {
-
+namespace equivfusion {
 /// Generate the code for registering passes.
 #define GEN_PASS_DECL_EQUIVFUSIONTEMPORALUNROLL
 #define GEN_PASS_REGISTRATION
+
 #include "circt-passes/TemporalUnroll/Passes.h.inc"
 
+} // namespace equivfusion
 } // namespace circt
 
 #endif //EQUIVFUSION_TEMPORAL_UNROLL_PASSES_H

--- a/infrastructure/base/unroll_command.cpp
+++ b/infrastructure/base/unroll_command.cpp
@@ -94,8 +94,8 @@ llvm::LogicalResult UnrollCommand::executeUnroll(const UnrollOptions &opts) {
     pm.enableVerifier(true);
     pm.enableTiming(ts);
 
-    circt::EquivFusionTemporalUnrollOptions timeUnrollOpts = {opts.steps};
-    pm.addPass(circt::createEquivFusionTemporalUnroll(timeUnrollOpts));
+    circt::equivfusion::EquivFusionTemporalUnrollOptions timeUnrollOpts = {opts.steps};
+    pm.addPass(circt::equivfusion::createEquivFusionTemporalUnroll(timeUnrollOpts));
 #if 0
     pm.addPass(mlir::createCSEPass());
     pm.addPass(mlir::createCanonicalizerPass());

--- a/infrastructure/circt-passes/FuncToHWModule/CMakeLists.txt
+++ b/infrastructure/circt-passes/FuncToHWModule/CMakeLists.txt
@@ -1,8 +1,8 @@
-add_circt_library(FuncToHWModule
+add_circt_library(EquivFusionFuncToHWModule
     func_to_hw_module.cpp
 
     DEPENDS
-    FuncToHWModuleIncGen
+    EquivFusionFuncToHWModuleIncGen
 
     LINK_LIBS PUBLIC
     MLIRControlFlowDialect

--- a/infrastructure/circt-passes/TemporalUnroll/temporal_unroll.cpp
+++ b/infrastructure/circt-passes/TemporalUnroll/temporal_unroll.cpp
@@ -7,8 +7,10 @@
 #include "mlir/IR/IRMapping.h"
 
 namespace circt {
+namespace equivfusion {
 #define GEN_PASS_DEF_EQUIVFUSIONTEMPORALUNROLL
 #include "circt-passes/TemporalUnroll/Passes.h.inc"
+} // namespace equivfusion
 } // namespace circt;
 
 using namespace circt;
@@ -16,8 +18,8 @@ using namespace mlir;
 
 namespace {
 struct EquivFusionTemporalUnrollPass
-    : public circt::impl::EquivFusionTemporalUnrollBase<EquivFusionTemporalUnrollPass> {
-    using circt::impl::EquivFusionTemporalUnrollBase<EquivFusionTemporalUnrollPass>::EquivFusionTemporalUnrollBase;
+        : public circt::equivfusion::impl::EquivFusionTemporalUnrollBase<EquivFusionTemporalUnrollPass> {
+    using circt::equivfusion::impl::EquivFusionTemporalUnrollBase<EquivFusionTemporalUnrollPass>::EquivFusionTemporalUnrollBase;
 
     void runOnOperation() override;
 

--- a/infrastructure/utils/CMakeLists.txt
+++ b/infrastructure/utils/CMakeLists.txt
@@ -22,7 +22,7 @@ target_link_libraries(EquivFusionUtils
     MLIRAffineToStandard
     MLIRAffineAnalysis
 
-    FuncToHWModule
+    EquivFusionFuncToHWModule
     EquivFusionRemoveRedundantFunc
     EquivFusionMemrefHLS
 )

--- a/infrastructure/utils/hls-util/populate_hls_passes.cpp
+++ b/infrastructure/utils/hls-util/populate_hls_passes.cpp
@@ -57,7 +57,7 @@ void populateHLSPasses(mlir::PassManager &pm) {
 
     //Convert Func to Module
     pm.addPass(mlir::createCanonicalizerPass());
-    pm.addPass(circt::createFuncToHWModule());
+    pm.addPass(circt::createEquivFusionFuncToHWModule());
     
     pm.addPass(mlir::createCanonicalizerPass());
 }

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -1,2 +1,3 @@
 add_subdirectory(circt-lec)
 add_subdirectory(equivfusion-hls)
+add_subdirectory(equivfusion-opt)

--- a/tools/equivfusion-opt/CMakeLists.txt
+++ b/tools/equivfusion-opt/CMakeLists.txt
@@ -1,0 +1,39 @@
+set(LLVM_LINK_COMPONENTS  Support)
+
+add_llvm_executable(equivfusion-opt equivfusion-opt.cpp)
+
+get_property(dialect_libs GLOBAL PROPERTY CIRCT_DIALECT_LIBS)
+get_property(conversion_libs GLOBAL PROPERTY CIRCT_CONVERSION_LIBS)
+
+target_link_libraries(equivfusion-opt
+    PRIVATE
+    ${dialect_libs}
+    ${conversion_libs}
+
+    MLIRIR
+    MLIRLLVMDialect
+    MLIRMemRefDialect
+    MLIROptLib
+    MLIRParser
+    MLIRFuncDialect
+    MLIRSupport
+    MLIRTransforms
+    MLIRSCFDialect
+    MLIREmitCDialect
+    MLIRFuncInlinerExtension
+    MLIRVectorDialect
+    MLIRIndexDialect
+    MLIRLLVMIRTransforms
+
+    EquivFusionPassCombTransforms
+    EquivFusionConvertCaseToLogicalComparison
+    EquivFusionFuncToHWModule
+    EquivFusionPassHWTransforms
+    EquivFusionMemrefHLS
+    EquivFusionPassEquivMiter
+    EquivFusionRemoveRedundantFunc
+    EquivFusionPassTemporalUnroll
+)
+
+llvm_update_compile_flags(equivfusion-opt)
+mlir_check_all_link_libraries(equivfusion-opt)

--- a/tools/equivfusion-opt/equivfusion-opt.cpp
+++ b/tools/equivfusion-opt/equivfusion-opt.cpp
@@ -1,0 +1,47 @@
+#include "circt/InitAllDialects.h"
+#include "circt/Support/LoweringOptions.h"
+#include "circt/Support/Version.h"
+#include "mlir/Dialect/Affine/IR/AffineOps.h"
+#include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Dialect/ControlFlow/IR/ControlFlowOps.h"
+#include "mlir/Dialect/EmitC/IR/EmitC.h"
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/Dialect/Index/IR/IndexDialect.h"
+#include "mlir/Dialect/LLVMIR/LLVMDialect.h"
+#include "mlir/Dialect/Math/IR/Math.h"
+#include "mlir/Dialect/MemRef/IR/MemRef.h"
+#include "mlir/Dialect/SCF/IR/SCF.h"
+#include "mlir/Dialect/Vector/IR/VectorOps.h"
+#include "mlir/Pass/PassRegistry.h"
+#include "mlir/Tools/mlir-opt/MlirOptMain.h"
+#include "llvm/Support/PrettyStackTrace.h"
+
+#include "circt-passes/InitAllPasses.h"
+
+int main(int argc, char **argv) {
+    // Set the bug report message to indicate users should file issues on
+    // llvm/circt and not llvm/llvm-project.
+    llvm::setBugReportMsg(circt::circtBugReportMsg);
+
+    mlir::DialectRegistry registry;
+
+    // Register MLIR stuff
+    registry.insert<mlir::affine::AffineDialect>();
+    registry.insert<mlir::math::MathDialect>();
+    registry.insert<mlir::LLVM::LLVMDialect>();
+    registry.insert<mlir::memref::MemRefDialect>();
+    registry.insert<mlir::func::FuncDialect>();
+    registry.insert<mlir::arith::ArithDialect>();
+    registry.insert<mlir::cf::ControlFlowDialect>();
+    registry.insert<mlir::scf::SCFDialect>();
+    registry.insert<mlir::emitc::EmitCDialect>();
+    registry.insert<mlir::vector::VectorDialect>();
+    registry.insert<mlir::index::IndexDialect>();
+
+    circt::registerAllDialects(registry);
+
+    circt::registerAllEquivFusionPasses();
+
+    return mlir::failed(mlir::MlirOptMain(
+            argc, argv, "EquivFusion opt", registry));
+}


### PR DESCRIPTION
【需求编号】
US-021

【需求描述】
添加equivfusion-opt的实现，支持option控制执行某个或某些pass【类似于circt-opt】

【一句话总结实现】
tools目录下添加equivfusion-opt的实现

【实现细节】
1. include/circt-passes/InitAllPasses.h中registerAllEquivFusionPasses()
2. tools/equivfusion-opt/equivfusion-opt.cpp中调用registerAllEquivFusionPasses()

【自测结果】