### PR TITLE
[Frontend][US-018]: Convert 'memref.get_global' to 'memref.alloc' + 'affine.store'

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,8 +45,8 @@ endif()
 # CIRCT Configuration
 # -------------------------------------------
 
-set(CIRCT_LINUX_DOWNLOAD_URL "https://github.com/llvm/circt/releases/download/firtool-1.132.0/circt-full-shared-linux-x64.tar.gz")
-set(CIRCT_APPLE_DOWNLOAD_URL "https://github.com/llvm/circt/releases/download/firtool-1.132.0/circt-full-shared-macos-x64.tar.gz")
+set(CIRCT_LINUX_DOWNLOAD_URL "https://github.com/llvm/circt/releases/download/firtool-1.138.0/circt-full-shared-linux-x64.tar.gz")
+set(CIRCT_APPLE_DOWNLOAD_URL "https://github.com/llvm/circt/releases/download/firtool-1.138.0/circt-full-shared-macos-x64.tar.gz")
 set(CIRCT_PREBUILD_DIR "${CMAKE_CURRENT_SOURCE_DIR}/circt_prebuild")
 set(CIRCT_TAR_PATH "${CIRCT_PREBUILD_DIR}/circt_prebuild.tar.gz")
 

--- a/include/circt-passes/MemrefHLS/Passes.td
+++ b/include/circt-passes/MemrefHLS/Passes.td
@@ -30,6 +30,16 @@ def EquivFusionSetFuncArgDirectionPass : Pass<"equivfusion-set-func-arg-directio
     ];
 }
 
+def EquivFusionGetGlobalToAllocPass : Pass<"equivfusion-get-global-to-alloc", "mlir::func::FuncOp"> {
+    let summary = "Convert 'memref.global_get' to 'memref.alloc' + 'affine.store'";
+
+    let description = [{
+        This Convert 'memref.global_get' to 'memref.alloc' + 'affine.store' in 'func.func'.
+    }];
+
+    let dependentDialects = ["mlir::func::FuncDialect", "mlir::arith::ArithDialect", "mlir::affine::AffineDialect", "mlir::memref::MemRefDialect"];
+}
+ 
 
 
 

--- a/infrastructure/circt-passes/MemrefHLS/CMakeLists.txt
+++ b/infrastructure/circt-passes/MemrefHLS/CMakeLists.txt
@@ -9,6 +9,9 @@ add_circt_library(EquivFusionMemrefHLS
     LINK_LIBS PUBLIC
     MLIRFuncDialect
     MLIRArithDialect
+    MLIRAffineDialect
+    MLIRMemRefDialect
+    MLIRTransformUtils
     MLIRIR
 
     LLVMSupport

--- a/infrastructure/circt-passes/MemrefHLS/get_global_to_alloc.cpp
+++ b/infrastructure/circt-passes/MemrefHLS/get_global_to_alloc.cpp
@@ -1,0 +1,247 @@
+#include "circt-passes/MemrefHLS/Passes.h"
+
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Dialect/Affine/IR/AffineOps.h"
+#include "mlir/Dialect/MemRef/IR/MemRef.h"
+#include "mlir/IR/BuiltinOps.h"
+#include "mlir/IR/Builders.h"
+#include "mlir/IR/Value.h"
+#include "mlir/IR/Types.h"
+#include "mlir/IR/Attributes.h"
+#include "mlir/Transforms/DialectConversion.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+#include "mlir/IR/BuiltinAttributes.h"
+#include "mlir/IR/DialectResourceBlobManager.h"
+
+#include "llvm/Support/Casting.h"
+#include "llvm/ADT/APInt.h"
+
+
+namespace circt {
+
+#define GEN_PASS_DEF_EQUIVFUSIONGETGLOBALTOALLOCPASS
+#include "circt-passes/MemrefHLS/Passes.h.inc"
+
+} // namespace circt
+
+namespace {
+
+struct GetGlobalToAllocRewriter : public mlir::OpRewritePattern<mlir::memref::GetGlobalOp> {
+    using mlir::OpRewritePattern<mlir::memref::GetGlobalOp>::OpRewritePattern;
+    
+    mlir::LogicalResult 
+    assignValueToMemref(mlir::PatternRewriter &rewriter, mlir::Value memref, size_t currentDim,
+        mlir::Attribute initialValueAttr, llvm::ArrayRef<int64_t> &shape, llvm::SmallVector<int64_t> &indices) const;
+
+    mlir::LogicalResult 
+    getDenseElementsAttrValue(mlir::PatternRewriter &rewriter, mlir::DenseElementsAttr denseAttr, 
+        mlir::Type elementType, size_t flatIndex, mlir::Value &constVal) const;
+
+    mlir::LogicalResult 
+    getDenseResourceElementsAttrValue(mlir::PatternRewriter &rewriter, mlir::DenseResourceElementsAttr denseResourceAttr, 
+        mlir::Type elementType, size_t flatIndex, mlir::Value &constVal) const;
+
+
+
+    mlir::LogicalResult matchAndRewrite(mlir::memref::GetGlobalOp op, mlir::PatternRewriter &rewriter) const override {
+        // Create 'memref.alloc' based on the result type of 'memref.get_global'.
+        mlir::MemRefType memrefType = llvm::dyn_cast<mlir::MemRefType>(op.getResult().getType());
+        mlir::Type elementType = memrefType.getElementType();
+
+        if (!memrefType.hasStaticShape()) {
+            llvm::errs() << "Error: Type of global memref is not a static shape!\n";
+            return mlir::failure();
+        }
+
+        if (!elementType.isInteger() && !elementType.isFloat()) {
+            llvm::errs() << "Error: Element type of global memerf is not integer or float!\n";
+            return mlir::failure();
+        }
+
+        mlir::memref::AllocOp allocOp = rewriter.create<mlir::memref::AllocOp>(op.getLoc(), memrefType);
+
+        // Assign values to the memref allocated by 'memref.alloc' based on global memref.
+        llvm::ArrayRef<int64_t> shape = memrefType.getShape();
+        mlir::Value newMemref = allocOp.getResult();
+
+        llvm::StringRef globalMemrefName = op.getName();
+        mlir::ModuleOp moduleOp = op->getParentOfType<mlir::ModuleOp>();
+        mlir::memref::GlobalOp globalOp = moduleOp.lookupSymbol<mlir::memref::GlobalOp>(globalMemrefName);
+
+        if (!globalOp) {
+            llvm::errs() << "Error: Global memref '" << globalMemrefName << "' not found!\n";
+            return mlir::failure();
+        }
+
+        if (!globalOp.getConstant()) {
+            llvm::errs() << "Error: Global memref '" << globalMemrefName << "' is not a constant!\n";
+            return mlir::failure();
+        }
+
+        std::optional<mlir::Attribute> initValueAttr = globalOp.getInitialValue();
+
+        if (initValueAttr.has_value() && !llvm::isa<mlir::UnitAttr>(*initValueAttr)) {
+            llvm::SmallVector<int64_t> indices;
+            if (mlir::failed(assignValueToMemref(rewriter, newMemref, 0, initValueAttr.value(), shape, indices))) {
+                return mlir::failure();
+            }
+        }
+
+        rewriter.replaceOp(op, allocOp);
+
+        return mlir::success();
+    }
+};
+
+struct EquivFusionGetGlobalToAllocPass : public circt::impl::EquivFusionGetGlobalToAllocPassBase<EquivFusionGetGlobalToAllocPass> {
+    using circt::impl::EquivFusionGetGlobalToAllocPassBase<EquivFusionGetGlobalToAllocPass>::EquivFusionGetGlobalToAllocPassBase;
+    
+    void runOnOperation() override;
+};
+
+} // namespace
+
+mlir::LogicalResult 
+GetGlobalToAllocRewriter::getDenseResourceElementsAttrValue(mlir::PatternRewriter &rewriter, mlir::DenseResourceElementsAttr denseResourceAttr, 
+    mlir::Type elementType, size_t flatIndex, mlir::Value &constVal) const {
+    
+     auto handle = denseResourceAttr.getRawHandle();
+     auto blob = handle.getBlob();
+
+     if (!blob) {
+        llvm::errs() << "Error: Blob of DenseResourceElementsAttr is null!\n";
+        return mlir::failure();
+     }
+
+     llvm::ArrayRef<char> data = blob->getData();
+     unsigned bitWidth = elementType.getIntOrFloatBitWidth();
+
+     if (elementType.isInteger()) {
+        unsigned byteWidth = (bitWidth + 7) / 8;
+
+        const uint8_t *ptr = reinterpret_cast<const uint8_t *>(data.data());
+        ptr += flatIndex * byteWidth;
+
+        llvm::APInt value;
+        if (bitWidth <= 64) {
+            uint64_t rawValue = 0;
+            memcpy(&rawValue, ptr, byteWidth);
+            value = llvm::APInt(bitWidth, rawValue, elementType.isSignedInteger());
+            auto elementAttr = rewriter.getIntegerAttr(elementType, value);
+            constVal = rewriter.create<mlir::arith::ConstantOp>(rewriter.getUnknownLoc(), elementType, elementAttr);
+        } else {
+            llvm::errs() << "Error: Integer element type Bit width of DenseResourceElementsAttr is greater than 64!\n";
+            return mlir::failure();
+        }
+     } else if (elementType.isFloat()) {
+        if (bitWidth == 32) { 
+            auto arrayRef = llvm::ArrayRef<float>(reinterpret_cast<const float *>(data.data()), data.size()/sizeof(float));
+            auto elementAttr = rewriter.getF32FloatAttr(arrayRef[flatIndex]);
+            constVal = rewriter.create<mlir::arith::ConstantOp>(rewriter.getUnknownLoc(), elementType, elementAttr);
+        } else if (bitWidth == 64) {
+            auto arrayRef = llvm::ArrayRef<double>(reinterpret_cast<const double *>(data.data()), data.size()/sizeof(double));
+            auto elementAttr = rewriter.getF64FloatAttr(arrayRef[flatIndex]);
+            constVal = rewriter.create<mlir::arith::ConstantOp>(rewriter.getUnknownLoc(), elementType, elementAttr);
+        } else {
+            llvm::errs() << "Error: Float element type Bit width of DenseResourceElementsAttr is not 32 or 64!\n";
+            return mlir::failure();
+        }
+     } else {
+        llvm::errs() << "Error: Element type of DenseResourceElementsAttr is not integer or float!\n";
+        return mlir::failure();
+     }
+
+
+    return mlir::success();
+}
+
+
+mlir::LogicalResult 
+GetGlobalToAllocRewriter::getDenseElementsAttrValue(mlir::PatternRewriter &rewriter, mlir::DenseElementsAttr denseAttr, 
+    mlir::Type elementType, size_t flatIndex, mlir::Value &constVal) const {
+    
+    if (elementType.isInteger()) {
+        auto initVals = denseAttr.getValues<llvm::APInt>();
+        auto it = initVals.begin() + flatIndex;
+        auto intAttr = rewriter.getIntegerAttr(elementType, *it);
+        auto initValConstOp = rewriter.create<mlir::arith::ConstantOp>(rewriter.getUnknownLoc(), elementType, intAttr);
+        constVal = initValConstOp.getResult();
+    } else if (elementType.isFloat()) {
+        auto initVals = denseAttr.getValues<llvm::APFloat>();
+        auto it = initVals.begin() + flatIndex;
+        auto floatAttr = rewriter.getFloatAttr(elementType, *it);
+        auto initValConstOp = rewriter.create<mlir::arith::ConstantOp>(rewriter.getUnknownLoc(), elementType, floatAttr);
+        constVal = initValConstOp.getResult();
+    } else {
+        llvm::errs() << "Error: Element type of dense attribute is not integer or float!\n";
+        return mlir::failure();
+    }
+
+    return mlir::success();
+}
+
+mlir::LogicalResult GetGlobalToAllocRewriter::assignValueToMemref(mlir::PatternRewriter &rewriter, mlir::Value memref, size_t currentDim,
+    mlir::Attribute initialValueAttr, llvm::ArrayRef<int64_t> &shape, llvm::SmallVector<int64_t> &indices) const {
+        if (currentDim == shape.size()) {
+            size_t flatIndex;
+            mlir::Value initValConst;
+            mlir::Type elementType = llvm::dyn_cast<mlir::MemRefType>(memref.getType()).getElementType();
+
+            if (shape.size() == 0) {
+                flatIndex = 0;
+            } else if(shape.size() == 1) {
+                flatIndex = indices[0];
+            } else {
+                flatIndex = 0;
+                for (size_t i = 0; i < shape.size() - 1; i++) { 
+                    flatIndex += indices[i] * shape[i];
+                }
+                flatIndex += indices[shape.size() - 1];
+            }
+
+            if (auto denseAttr = llvm::dyn_cast<mlir::DenseElementsAttr>(initialValueAttr)) {
+                if (mlir::failed(getDenseElementsAttrValue(rewriter, denseAttr, elementType, flatIndex, initValConst))) {
+                    return mlir::failure();
+                }
+            } else if (auto resourceAttr = llvm::dyn_cast<mlir::DenseResourceElementsAttr>(initialValueAttr)) {
+                if (mlir::failed(getDenseResourceElementsAttrValue(rewriter, resourceAttr, elementType, flatIndex, initValConst))) {
+                    return mlir::failure();
+                }
+            } else {
+                llvm::errs() << "Error: Initial value is not a supported dense attribute type!\n";
+                return mlir::failure();
+            }
+
+            llvm::SmallVector<mlir::Value> indexValues;
+            for (size_t i : indices) {
+                auto idxConstOp = rewriter.create<mlir::arith::ConstantOp>(rewriter.getUnknownLoc(), rewriter.getIndexType(), rewriter.getIndexAttr(i));
+                indexValues.push_back(idxConstOp.getResult());
+            }
+
+            rewriter.create<mlir::affine::AffineStoreOp>(rewriter.getUnknownLoc(), initValConst, memref, indexValues);
+
+            return mlir::success();
+        }
+
+        for (size_t i = 0; i < shape[currentDim]; i++) {
+            indices.push_back(i);
+            if (mlir::failed(assignValueToMemref(rewriter, memref, currentDim + 1, initialValueAttr, shape, indices))) {
+                return mlir::failure();
+            }
+            indices.pop_back();
+        }
+
+        return mlir::success();
+    }
+
+void EquivFusionGetGlobalToAllocPass::runOnOperation() {
+    mlir::RewritePatternSet patterns(&getContext());
+    patterns.add<GetGlobalToAllocRewriter>(patterns.getContext());
+    mlir::FrozenRewritePatternSet frozen(std::move(patterns));
+
+    if (mlir::failed(mlir::applyPatternsGreedily(getOperation(), frozen))) {
+        signalPassFailure();
+    }
+}
+

--- a/test/integration_tests/cases/dot64_run_bitwuzla_with_btor2/dot64.v
+++ b/test/integration_tests/cases/dot64_run_bitwuzla_with_btor2/dot64.v
@@ -1,0 +1,51 @@
+module dot64_comb #(
+    parameter N       = 64,   // Vector length
+    parameter W       = 16,   // Bit-width of each element (signed)
+    parameter ACC_W   = 48    // Bit-width of accumulator/output
+)(
+    // Two signed input vectors, each containing N elements of W bits
+    input  logic signed [W-1:0] arg_0 [0:N-1],
+    input  logic signed [W-1:0] arg_1 [0:N-1],
+
+    // Signed output: dot product result (sum of element-wise products)
+    output logic signed [ACC_W-1:0] out_0
+);
+
+    //============================================================
+    // 1. Element-wise multiplications
+    // Each pair a[i], b[i] is multiplied to produce a 2*W-bit product.
+    //============================================================
+    logic signed [(2*W)-1:0] prod [0:N-1];
+
+    genvar i;
+    generate
+        for (i = 0; i < N; i = i + 1) begin : GEN_PROD
+            assign prod[i] = arg_0[i] * arg_1[i];
+        end
+    endgenerate
+
+    //============================================================
+    // 2. Summation of all products
+    // This always block performs a combinational reduction (sum)
+    // across all products. The result is stored in sum_reg.
+    //============================================================
+    integer k;
+    logic signed [ACC_W-1:0] sum_reg;
+
+    always @(*) begin
+        sum_reg = '0; // Initialize accumulator to zero
+        for (k = 0; k < N; k = k + 1) begin
+            // Sign-extend each 2*W-bit product to ACC_W bits
+            // before adding, to prevent overflow and preserve sign.
+            sum_reg = sum_reg +
+                {{(ACC_W-(2*W)){prod[k][(2*W)-1]}}, prod[k]};
+        end
+    end
+
+    //============================================================
+    // 3. Final output assignment
+    // The dot product is simply the total accumulated sum.
+    //============================================================
+    assign out_0 = sum_reg;
+
+endmodule

--- a/test/integration_tests/cases/dot64_run_bitwuzla_with_btor2/dot64_run_bitwuzla_with_btor2.sh
+++ b/test/integration_tests/cases/dot64_run_bitwuzla_with_btor2/dot64_run_bitwuzla_with_btor2.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/bash
+
+set -euo pipefail
+
+CASE_DIR=$(dirname "$(realpath "$0")")
+OUTPUT_DIR=${CASE_LOG_PATH:-.}
+
+#CHECK: unsat
+equiv_fusion -p "read_c -spec -top mm mm.mlir" \
+             -p "read_v -impl -top dot64_comb dot64.v" \
+             -p "equiv_miter -specModule mm -implModule dot64_comb -mitermode btor2 -o $OUTPUT_DIR/miter.btor2" \
+             -p "solver_runner --solver bitwuzla --inputfile $OUTPUT_DIR/miter.btor2"

--- a/test/integration_tests/cases/dot64_run_bitwuzla_with_btor2/mm.mlir
+++ b/test/integration_tests/cases/dot64_run_bitwuzla_with_btor2/mm.mlir
@@ -1,0 +1,26 @@
+module {
+  func.func @mm(%arg0: memref<64xi16>, %arg1: memref<64xi16>) -> i48 {
+    %c0_i64 = arith.constant 0 : i48
+    %alloc = memref.alloc() {alignment = 64 : i64} : memref<64xi32>
+    affine.for %arg2 = 0 to 64 {
+      %2 = affine.load %arg0[%arg2] : memref<64xi16>
+      %3 = affine.load %arg1[%arg2] : memref<64xi16>
+      %4 = arith.extsi %2 : i16 to i32
+      %5 = arith.extsi %3 : i16 to i32
+      %6 = arith.muli %4, %5 : i32
+      affine.store %6, %alloc[%arg2] : memref<64xi32>
+    }
+    %alloc_0 = memref.alloc() {alignment = 64 : i64} : memref<i48>
+    affine.store %c0_i64, %alloc_0[] : memref<i48>
+    affine.for %arg2 = 0 to 64 {
+      %2 = affine.load %alloc[%arg2] : memref<64xi32>
+      %3 = affine.load %alloc_0[] : memref<i48>
+      %4 = arith.extsi %2 : i32 to i48
+      %5 = arith.addi %4, %3 : i48
+      affine.store %5, %alloc_0[] : memref<i48>
+    }
+    %0 = affine.load %alloc_0[] : memref<i48>
+    return %0 : i48
+  }
+}
+

--- a/test/integration_tests/cases/dot64_run_bitwuzla_with_btor2/test_dot.py
+++ b/test/integration_tests/cases/dot64_run_bitwuzla_with_btor2/test_dot.py
@@ -1,0 +1,29 @@
+from typing import List
+
+import torch
+import torch.nn as nn
+
+from torch_mlir import fx
+
+import os
+import sys
+
+class DotModule(torch.nn.Module):
+  def mm(self, a, b):
+    return torch.dot(a, b)
+  
+  def forward(self, a, b):
+    return self.mm(a, b)
+  
+model = DotModule()
+
+x = torch.randint(low=-128, high=128, size=(64,), dtype=torch.int16)
+y = torch.randint(low=-128, high=128, size=(64,), dtype=torch.int16)
+
+m = fx.export_and_import(model, x, y, output_type="linalg-on-tensors", func_name="mm")
+
+current_script_path = os.path.abspath(__file__)
+current_script_dir = os.path.dirname(current_script_path)
+
+with open(os.path.join(current_script_dir, "mm.mlir"), "w") as f:
+    f.write(str(m))

--- a/test/integration_tests/cases/dot64_run_btormc_with_btor2/dot64.v
+++ b/test/integration_tests/cases/dot64_run_btormc_with_btor2/dot64.v
@@ -1,0 +1,51 @@
+module dot64_comb #(
+    parameter N       = 64,   // Vector length
+    parameter W       = 16,   // Bit-width of each element (signed)
+    parameter ACC_W   = 48    // Bit-width of accumulator/output
+)(
+    // Two signed input vectors, each containing N elements of W bits
+    input  logic signed [W-1:0] arg_0 [0:N-1],
+    input  logic signed [W-1:0] arg_1 [0:N-1],
+
+    // Signed output: dot product result (sum of element-wise products)
+    output logic signed [ACC_W-1:0] out_0
+);
+
+    //============================================================
+    // 1. Element-wise multiplications
+    // Each pair a[i], b[i] is multiplied to produce a 2*W-bit product.
+    //============================================================
+    logic signed [(2*W)-1:0] prod [0:N-1];
+
+    genvar i;
+    generate
+        for (i = 0; i < N; i = i + 1) begin : GEN_PROD
+            assign prod[i] = arg_0[i] * arg_1[i];
+        end
+    endgenerate
+
+    //============================================================
+    // 2. Summation of all products
+    // This always block performs a combinational reduction (sum)
+    // across all products. The result is stored in sum_reg.
+    //============================================================
+    integer k;
+    logic signed [ACC_W-1:0] sum_reg;
+
+    always @(*) begin
+        sum_reg = '0; // Initialize accumulator to zero
+        for (k = 0; k < N; k = k + 1) begin
+            // Sign-extend each 2*W-bit product to ACC_W bits
+            // before adding, to prevent overflow and preserve sign.
+            sum_reg = sum_reg +
+                {{(ACC_W-(2*W)){prod[k][(2*W)-1]}}, prod[k]};
+        end
+    end
+
+    //============================================================
+    // 3. Final output assignment
+    // The dot product is simply the total accumulated sum.
+    //============================================================
+    assign out_0 = sum_reg;
+
+endmodule

--- a/test/integration_tests/cases/dot64_run_btormc_with_btor2/dot64_run_btormc_with_btor2.sh
+++ b/test/integration_tests/cases/dot64_run_btormc_with_btor2/dot64_run_btormc_with_btor2.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/bash
+
+set -euo pipefail
+
+CASE_DIR=$(dirname "$(realpath "$0")")
+OUTPUT_DIR=${CASE_LOG_PATH:-.}
+
+#CHECK: unsat
+equiv_fusion -p "read_c -spec -top mm mm.mlir" \
+             -p "read_v -impl -top dot64_comb dot64.v" \
+             -p "equiv_miter -specModule mm -implModule dot64_comb -mitermode btor2 -o $OUTPUT_DIR/miter.btor" \
+             -p "solver_runner --solver btormc --inputfile $OUTPUT_DIR/miter.btor"

--- a/test/integration_tests/cases/dot64_run_btormc_with_btor2/mm.mlir
+++ b/test/integration_tests/cases/dot64_run_btormc_with_btor2/mm.mlir
@@ -1,0 +1,26 @@
+module {
+  func.func @mm(%arg0: memref<64xi16>, %arg1: memref<64xi16>) -> i48 {
+    %c0_i64 = arith.constant 0 : i48
+    %alloc = memref.alloc() {alignment = 64 : i64} : memref<64xi32>
+    affine.for %arg2 = 0 to 64 {
+      %2 = affine.load %arg0[%arg2] : memref<64xi16>
+      %3 = affine.load %arg1[%arg2] : memref<64xi16>
+      %4 = arith.extsi %2 : i16 to i32
+      %5 = arith.extsi %3 : i16 to i32
+      %6 = arith.muli %4, %5 : i32
+      affine.store %6, %alloc[%arg2] : memref<64xi32>
+    }
+    %alloc_0 = memref.alloc() {alignment = 64 : i64} : memref<i48>
+    affine.store %c0_i64, %alloc_0[] : memref<i48>
+    affine.for %arg2 = 0 to 64 {
+      %2 = affine.load %alloc[%arg2] : memref<64xi32>
+      %3 = affine.load %alloc_0[] : memref<i48>
+      %4 = arith.extsi %2 : i32 to i48
+      %5 = arith.addi %4, %3 : i48
+      affine.store %5, %alloc_0[] : memref<i48>
+    }
+    %0 = affine.load %alloc_0[] : memref<i48>
+    return %0 : i48
+  }
+}
+

--- a/test/integration_tests/cases/dot64_run_btormc_with_btor2/test_dot.py
+++ b/test/integration_tests/cases/dot64_run_btormc_with_btor2/test_dot.py
@@ -1,0 +1,29 @@
+from typing import List
+
+import torch
+import torch.nn as nn
+
+from torch_mlir import fx
+
+import os
+import sys
+
+class DotModule(torch.nn.Module):
+  def mm(self, a, b):
+    return torch.dot(a, b)
+  
+  def forward(self, a, b):
+    return self.mm(a, b)
+  
+model = DotModule()
+
+x = torch.randint(low=-128, high=128, size=(64,), dtype=torch.int16)
+y = torch.randint(low=-128, high=128, size=(64,), dtype=torch.int16)
+
+m = fx.export_and_import(model, x, y, output_type="linalg-on-tensors", func_name="mm")
+
+current_script_path = os.path.abspath(__file__)
+current_script_dir = os.path.dirname(current_script_path)
+
+with open(os.path.join(current_script_dir, "mm.mlir"), "w") as f:
+    f.write(str(m))

--- a/test/integration_tests/cases/dot64_run_kissat_with_aiger2/dot64.v
+++ b/test/integration_tests/cases/dot64_run_kissat_with_aiger2/dot64.v
@@ -1,0 +1,51 @@
+module dot64_comb #(
+    parameter N       = 64,   // Vector length
+    parameter W       = 16,   // Bit-width of each element (signed)
+    parameter ACC_W   = 48    // Bit-width of accumulator/output
+)(
+    // Two signed input vectors, each containing N elements of W bits
+    input  logic signed [W-1:0] arg_0 [0:N-1],
+    input  logic signed [W-1:0] arg_1 [0:N-1],
+
+    // Signed output: dot product result (sum of element-wise products)
+    output logic signed [ACC_W-1:0] out_0
+);
+
+    //============================================================
+    // 1. Element-wise multiplications
+    // Each pair a[i], b[i] is multiplied to produce a 2*W-bit product.
+    //============================================================
+    logic signed [(2*W)-1:0] prod [0:N-1];
+
+    genvar i;
+    generate
+        for (i = 0; i < N; i = i + 1) begin : GEN_PROD
+            assign prod[i] = arg_0[i] * arg_1[i];
+        end
+    endgenerate
+
+    //============================================================
+    // 2. Summation of all products
+    // This always block performs a combinational reduction (sum)
+    // across all products. The result is stored in sum_reg.
+    //============================================================
+    integer k;
+    logic signed [ACC_W-1:0] sum_reg;
+
+    always @(*) begin
+        sum_reg = '0; // Initialize accumulator to zero
+        for (k = 0; k < N; k = k + 1) begin
+            // Sign-extend each 2*W-bit product to ACC_W bits
+            // before adding, to prevent overflow and preserve sign.
+            sum_reg = sum_reg +
+                {{(ACC_W-(2*W)){prod[k][(2*W)-1]}}, prod[k]};
+        end
+    end
+
+    //============================================================
+    // 3. Final output assignment
+    // The dot product is simply the total accumulated sum.
+    //============================================================
+    assign out_0 = sum_reg;
+
+endmodule

--- a/test/integration_tests/cases/dot64_run_kissat_with_aiger2/dot64_run_kissat_with_aiger2.sh
+++ b/test/integration_tests/cases/dot64_run_kissat_with_aiger2/dot64_run_kissat_with_aiger2.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/bash
+
+set -euo pipefail
+
+CASE_DIR=$(dirname "$(realpath "$0")")
+OUTPUT_DIR=${CASE_LOG_PATH:-.}
+
+equiv_fusion -p "read_c -spec -top mm mm.mlir" \
+             -p "read_v -impl -top dot64_comb dot64.v" \
+             -p "equiv_miter -specModule mm -implModule dot64_comb -mitermode aiger -o $OUTPUT_DIR/miter.aiger" \
+             -p "solver_runner --solver kissat --inputfile $OUTPUT_DIR/miter.aiger"
+
+aigtocnf $OUTPUT_DIR/miter.aiger $OUTPUT_DIR/miter.cnf
+
+#CHECK: UNSATISFIABLE
+equiv_fusion -p "solver_runner --solver kissat --inputfile $OUTPUT_DIR/miter.cnf"

--- a/test/integration_tests/cases/dot64_run_kissat_with_aiger2/mm.mlir
+++ b/test/integration_tests/cases/dot64_run_kissat_with_aiger2/mm.mlir
@@ -1,0 +1,26 @@
+module {
+  func.func @mm(%arg0: memref<64xi16>, %arg1: memref<64xi16>) -> i48 {
+    %c0_i64 = arith.constant 0 : i48
+    %alloc = memref.alloc() {alignment = 64 : i64} : memref<64xi32>
+    affine.for %arg2 = 0 to 64 {
+      %2 = affine.load %arg0[%arg2] : memref<64xi16>
+      %3 = affine.load %arg1[%arg2] : memref<64xi16>
+      %4 = arith.extsi %2 : i16 to i32
+      %5 = arith.extsi %3 : i16 to i32
+      %6 = arith.muli %4, %5 : i32
+      affine.store %6, %alloc[%arg2] : memref<64xi32>
+    }
+    %alloc_0 = memref.alloc() {alignment = 64 : i64} : memref<i48>
+    affine.store %c0_i64, %alloc_0[] : memref<i48>
+    affine.for %arg2 = 0 to 64 {
+      %2 = affine.load %alloc[%arg2] : memref<64xi32>
+      %3 = affine.load %alloc_0[] : memref<i48>
+      %4 = arith.extsi %2 : i32 to i48
+      %5 = arith.addi %4, %3 : i48
+      affine.store %5, %alloc_0[] : memref<i48>
+    }
+    %0 = affine.load %alloc_0[] : memref<i48>
+    return %0 : i48
+  }
+}
+

--- a/test/integration_tests/cases/dot64_run_kissat_with_aiger2/test_dot.py
+++ b/test/integration_tests/cases/dot64_run_kissat_with_aiger2/test_dot.py
@@ -1,0 +1,29 @@
+from typing import List
+
+import torch
+import torch.nn as nn
+
+from torch_mlir import fx
+
+import os
+import sys
+
+class DotModule(torch.nn.Module):
+  def mm(self, a, b):
+    return torch.dot(a, b)
+  
+  def forward(self, a, b):
+    return self.mm(a, b)
+  
+model = DotModule()
+
+x = torch.randint(low=-128, high=128, size=(64,), dtype=torch.int16)
+y = torch.randint(low=-128, high=128, size=(64,), dtype=torch.int16)
+
+m = fx.export_and_import(model, x, y, output_type="linalg-on-tensors", func_name="mm")
+
+current_script_path = os.path.abspath(__file__)
+current_script_dir = os.path.dirname(current_script_path)
+
+with open(os.path.join(current_script_dir, "mm.mlir"), "w") as f:
+    f.write(str(m))

--- a/test/integration_tests/cases/dot64_run_z3_with_smt2/test_dot.py
+++ b/test/integration_tests/cases/dot64_run_z3_with_smt2/test_dot.py
@@ -1,0 +1,29 @@
+from typing import List
+
+import torch
+import torch.nn as nn
+
+from torch_mlir import fx
+
+import os
+import sys
+
+class DotModule(torch.nn.Module):
+  def mm(self, a, b):
+    return torch.dot(a, b)
+  
+  def forward(self, a, b):
+    return self.mm(a, b)
+  
+model = DotModule()
+
+x = torch.randint(low=-128, high=128, size=(64,), dtype=torch.int16)
+y = torch.randint(low=-128, high=128, size=(64,), dtype=torch.int16)
+
+m = fx.export_and_import(model, x, y, output_type="linalg-on-tensors", func_name="mm")
+
+current_script_path = os.path.abspath(__file__)
+current_script_dir = os.path.dirname(current_script_path)
+
+with open(os.path.join(current_script_dir, "mm.mlir"), "w") as f:
+    f.write(str(m))

--- a/test/integration_tests/cases/memref_get_global_to_alloc_test/fullyConnected_affine.mlir
+++ b/test/integration_tests/cases/memref_get_global_to_alloc_test/fullyConnected_affine.mlir
@@ -1,0 +1,125 @@
+module {
+  memref.global "private" constant @__constant_1xf32 : memref<1xf32> = dense<0.241402462> {alignment = 64 : i64}
+  memref.global "private" constant @__constant_1x3xf32 : memref<1x3xf32> = dense_resource<torch_tensor_1_3_torch.float32> {alignment = 64 : i64}
+  memref.global "private" constant @__constant_3xf32_1 : memref<3xf32> = dense_resource<torch_tensor_3_torch.float32_1> {alignment = 64 : i64}
+  memref.global "private" constant @__constant_3x3xf32_0 : memref<3x3xf32> = dense_resource<torch_tensor_3_3_torch.float32_1> {alignment = 64 : i64}
+  memref.global "private" constant @__constant_3x3xf32 : memref<3x3xf32> = dense_resource<torch_tensor_3_3_torch.float32> {alignment = 64 : i64}
+  memref.global "private" constant @__constant_3xf32 : memref<3xf32> = dense_resource<torch_tensor_3_torch.float32> {alignment = 64 : i64}
+  func.func @fullyConnected(%arg0: memref<1x3xf32>) -> memref<1x1xf32> {
+    %cst = arith.constant 0.241402462 : f32
+    %cst_0 = arith.constant 0.000000e+00 : f32
+    %0 = memref.get_global @__constant_3xf32 : memref<3xf32>
+    %1 = memref.get_global @__constant_3x3xf32 : memref<3x3xf32>
+    %2 = memref.get_global @__constant_3x3xf32_0 : memref<3x3xf32>
+    %3 = memref.get_global @__constant_3xf32_1 : memref<3xf32>
+    %4 = memref.get_global @__constant_1x3xf32 : memref<1x3xf32>
+    %alloc = memref.alloc() {alignment = 64 : i64} : memref<3x3xf32>
+    affine.for %arg1 = 0 to 3 {
+      affine.for %arg2 = 0 to 3 {
+        %5 = affine.load %1[%arg2, %arg1] : memref<3x3xf32>
+        affine.store %5, %alloc[%arg1, %arg2] : memref<3x3xf32>
+      }
+    }
+    %alloc_1 = memref.alloc() {alignment = 64 : i64} : memref<1x3xf32>
+    %alloc_2 = memref.alloc() {alignment = 64 : i64} : memref<1x3xf32>
+    affine.for %arg1 = 0 to 1 {
+      affine.for %arg2 = 0 to 3 {
+        affine.store %cst_0, %alloc_2[%arg1, %arg2] : memref<1x3xf32>
+      }
+    }
+    %alloc_3 = memref.alloc() {alignment = 64 : i64} : memref<1x3xf32>
+    memref.copy %alloc_2, %alloc_3 : memref<1x3xf32> to memref<1x3xf32>
+    affine.for %arg1 = 0 to 1 {
+      affine.for %arg2 = 0 to 3 {
+        affine.for %arg3 = 0 to 3 {
+          %5 = affine.load %arg0[%arg1, %arg3] : memref<1x3xf32>
+          %6 = affine.load %alloc[%arg3, %arg2] : memref<3x3xf32>
+          %7 = affine.load %alloc_3[%arg1, %arg2] : memref<1x3xf32>
+          %8 = arith.mulf %5, %6 : f32
+          %9 = arith.addf %7, %8 : f32
+          affine.store %9, %alloc_3[%arg1, %arg2] : memref<1x3xf32>
+        }
+      }
+    }
+    affine.for %arg1 = 0 to 1 {
+      affine.for %arg2 = 0 to 3 {
+        %5 = affine.load %alloc_3[%arg1, %arg2] : memref<1x3xf32>
+        %6 = affine.load %0[%arg2] : memref<3xf32>
+        %7 = arith.addf %5, %6 : f32
+        affine.store %7, %alloc_1[%arg1, %arg2] : memref<1x3xf32>
+      }
+    }
+    affine.for %arg1 = 0 to 3 {
+      affine.for %arg2 = 0 to 3 {
+        %5 = affine.load %2[%arg2, %arg1] : memref<3x3xf32>
+        affine.store %5, %alloc[%arg1, %arg2] : memref<3x3xf32>
+      }
+    }
+    affine.for %arg1 = 0 to 1 {
+      affine.for %arg2 = 0 to 3 {
+        affine.for %arg3 = 0 to 3 {
+          %5 = affine.load %alloc_1[%arg1, %arg3] : memref<1x3xf32>
+          %6 = affine.load %alloc[%arg3, %arg2] : memref<3x3xf32>
+          %7 = affine.load %alloc_2[%arg1, %arg2] : memref<1x3xf32>
+          %8 = arith.mulf %5, %6 : f32
+          %9 = arith.addf %7, %8 : f32
+          affine.store %9, %alloc_2[%arg1, %arg2] : memref<1x3xf32>
+        }
+      }
+    }
+    affine.for %arg1 = 0 to 1 {
+      affine.for %arg2 = 0 to 3 {
+        %5 = affine.load %alloc_2[%arg1, %arg2] : memref<1x3xf32>
+        %6 = affine.load %3[%arg2] : memref<3xf32>
+        %7 = arith.addf %5, %6 : f32
+        affine.store %7, %alloc_1[%arg1, %arg2] : memref<1x3xf32>
+      }
+    }
+    %alloc_4 = memref.alloc() {alignment = 64 : i64} : memref<3x1xf32>
+    affine.for %arg1 = 0 to 3 {
+      affine.for %arg2 = 0 to 1 {
+        %5 = affine.load %4[%arg2, %arg1] : memref<1x3xf32>
+        affine.store %5, %alloc_4[%arg1, %arg2] : memref<3x1xf32>
+      }
+    }
+    %alloc_5 = memref.alloc() {alignment = 64 : i64} : memref<1x1xf32>
+    affine.for %arg1 = 0 to 1 {
+      affine.for %arg2 = 0 to 1 {
+        affine.store %cst_0, %alloc_5[%arg1, %arg2] : memref<1x1xf32>
+      }
+    }
+    affine.for %arg1 = 0 to 1 {
+      affine.for %arg2 = 0 to 1 {
+        affine.for %arg3 = 0 to 3 {
+          %5 = affine.load %alloc_1[%arg1, %arg3] : memref<1x3xf32>
+          %6 = affine.load %alloc_4[%arg3, %arg2] : memref<3x1xf32>
+          %7 = affine.load %alloc_5[%arg1, %arg2] : memref<1x1xf32>
+          %8 = arith.mulf %5, %6 : f32
+          %9 = arith.addf %7, %8 : f32
+          affine.store %9, %alloc_5[%arg1, %arg2] : memref<1x1xf32>
+        }
+      }
+    }
+    affine.for %arg1 = 0 to 1 {
+      affine.for %arg2 = 0 to 1 {
+        %5 = affine.load %alloc_5[%arg1, %arg2] : memref<1x1xf32>
+        %6 = arith.addf %5, %cst : f32
+        affine.store %6, %alloc_5[%arg1, %arg2] : memref<1x1xf32>
+      }
+    }
+    return %alloc_5 : memref<1x1xf32>
+  }
+}
+
+{-#
+  dialect_resources: {
+    builtin: {
+      torch_tensor_1_3_torch.float32: "0x04000000CDCEE5BE6599033FBD3523BE",
+      torch_tensor_3_torch.float32_1: "0x04000000101D123E342E5DBE930BD7BD",
+      torch_tensor_3_3_torch.float32_1: "0x0400000076DC093FD304EC3D47B7A03CAED8FFBE9324103F9BB9873EEE50823EB9864E3EBDFB793E",
+      torch_tensor_3_3_torch.float32: "0x04000000C94E753E24B505BF9813CB3E822F023ED090523E1EB12FBE32CCB53ED3F411BF4850B73E",
+      torch_tensor_3_torch.float32: "0x040000000ADD02BD3238A7BE3AD4463E"
+    }
+  }
+#-}
+

--- a/test/integration_tests/cases/memref_get_global_to_alloc_test/memref_get_global_to_alloc_test.sh
+++ b/test/integration_tests/cases/memref_get_global_to_alloc_test/memref_get_global_to_alloc_test.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/bash
+
+set -euo pipefail
+
+CASE_DIR=$(dirname "$(realpath "$0")")
+OUTPUT_DIR=${CASE_LOG_PATH:-.}
+
+
+#CHECK-NOT: memref.get_global
+equivfusion-opt "fullyConnected_affine.mlir" --equivfusion-get-global-to-alloc
+
+


### PR DESCRIPTION
【需求编号】
    US-018

【需求描述】
    在EquivFusionHLS Flow中支持对memref.get_global操作。

【一句话总结实现】
    将函数中的memref.get_global操作替换位memref.alloc + affine.store操作。

【具体实现】
    先验假设：
        - memref.global必须为维度大小已知的memref。
        - memref.global必须是const类型。
        - 若memref.global没有初值，会认为初值为0
    
    实现思路：
        - memref.global没有初值的: 直接替换为类型相同的memref.alloc操作
        - memref.global有初值的：替换为类型相同的memref.alloc操作后，遍历所有memref.global中的元素，将相应的初值使用affine.store操作存入memre.alloc申请的memref中