### PR TITLE
[Miter][US-019]: Add multi_array[idx][idx] in case array_rtl2rtl

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@ __pycache__
 
 # dependent solvers
 solving/dep_solvers
+
+# dependent circt
+circt_prebuild

--- a/infrastructure/base/equiv_miter_command.cpp
+++ b/infrastructure/base/equiv_miter_command.cpp
@@ -1,4 +1,3 @@
-#include "infrastructure/managers/equivfusion_manager/equivfusionManager.h"
 #include "infrastructure/base/command.h"
 #include "infrastructure/utils/log-util/log_util.h"
 
@@ -15,7 +14,7 @@ public:
     }
 
     void execute(const std::vector<std::string>& args) override {
-        if (!EquivMiterTool::run(args)) {
+        if (!EquivMiterTool::executeMiter(args)) {
             logError("Command 'equiv_miter' failed!\n");
         }
     }
@@ -24,7 +23,16 @@ public:
     }
 
     void help() override {
-        EquivMiterTool::help(getName(), getDescription());
+        log("\n");
+        log("   OVERVIEW: %s - %s\n", getName().c_str(), getDescription().c_str());;
+        log("   USAGE:    %s <--specModule name> <--implModule name> [options]\n", getName().c_str());
+        log("   OPTIONS:\n");
+        log("       --print-ir ----------------------------- Print IR after pass\n");
+        log("       --specModule <module name> ------------- Specify a named module for the specification circuit\n");
+        log("       --implModule <module name> ------------- Specify a named module for the implementation circuit\n");
+        log("       --mitermode ---------------------------- MiterMode [smtlib, aiger, btor2], default is smtlib\n");
+        log("       -o ------------------------------------- Output filename\n");
+        log("\n\n");
     }
 } equivMiterCmd;
 

--- a/infrastructure/base/solver_command.cpp
+++ b/infrastructure/base/solver_command.cpp
@@ -4,6 +4,12 @@
 
 XUANSONG_NAMESPACE_HEADER_START
 
+struct SolverCommandOptions {
+    std::string solver = "";
+    std::string inputFile = "";
+    std::string options = "";
+};
+
 struct SolverCommand : public Command {
 public:
     SolverCommand() : Command("solver_runner", "run solver") {}
@@ -13,27 +19,12 @@ public:
     }
 
     void execute(const std::vector<std::string>& args) override {
-        std::string solver = "";
-        std::string inputFile = "";
-        std::string opts = "";
-        
-        for (size_t argidx = 0; argidx < args.size(); argidx++) {
-            if (args[argidx] == "--solver" && argidx + 1 < args.size()) {
-                solver = args[++argidx].c_str();
-            } else if (args[argidx] == "--inputfile" && argidx + 1 < args.size()) {
-                inputFile = args[++argidx].c_str();
-            } else if (args[argidx] == "--opts" && argidx + 1 < args.size()) {
-                opts = args[++argidx].c_str();
-            }
-        }
-        
-        if (solver.empty() || inputFile.empty()) {
-            log("Command solver_runner Failed:\n");
-            if (solver.empty())     log("   --solver is required!\n");
-            if (inputFile.empty())  log("   --inputfile is required!\n");
+        SolverCommandOptions opts;
+        if (!parseOptions(args, opts)) {
             return;
         }
-        XuanSong::SolverRunner::run(solver, inputFile, opts);
+
+        XuanSong::SolverRunner::run(opts.solver, opts.inputFile, opts.options);
     }
 
     void postExecute() override {
@@ -49,7 +40,29 @@ public:
         log("       --opts <options>\n");
         log("\n");
     }
-
+private:
+    bool parseOptions(const std::vector<std::string>& args, SolverCommandOptions& opts);
 } solverCommand;
+
+bool SolverCommand::parseOptions(const std::vector<std::string>& args, SolverCommandOptions& opts) {
+    for (size_t argidx = 0; argidx < args.size(); argidx++) {
+        if (args[argidx] == "--solver" && argidx + 1 < args.size()) {
+            opts.solver = args[++argidx];
+        } else if (args[argidx] == "--inputfile" && argidx + 1 < args.size()) {
+            opts.inputFile = args[++argidx];
+        } else if (args[argidx] == "--opts" && argidx + 1 < args.size()) {
+            opts.options = args[++argidx];
+        }
+    }
+
+    if (opts.solver.empty() || opts.inputFile.empty()) {
+        log("Command solver_runner Failed:\n");
+        if (opts.solver.empty())     log("   --solver is required!\n");
+        if (opts.inputFile.empty())  log("   --inputfile is required!\n");
+        return false;
+    }
+
+    return true;
+}
 
 XUANSONG_NAMESPACE_HEADER_END

--- a/infrastructure/base/unroll_command.cpp
+++ b/infrastructure/base/unroll_command.cpp
@@ -11,7 +11,7 @@ XUANSONG_NAMESPACE_HEADER_START
 
 struct UnrollOptions {
     unsigned steps = 1;
-    ModuleType moduleType {ModuleType::UNKNOWN};
+    ModuleTypeEnum moduleType {ModuleTypeEnum::UNKNOWN};
 };
 
 struct UnrollCommand : public Command {
@@ -60,12 +60,12 @@ bool UnrollCommand::parseOptions(const std::vector<std::string> &args, UnrollOpt
         if ((args[idx] == "--steps" || args[idx] == "-steps") && (idx + 1 < args.size())) {
             opts.steps = std::stoi(args[++idx]);
         } if (args[idx] == "--spec" || args[idx] == "-spec") {
-            opts.moduleType = ModuleType::SPEC;
+            opts.moduleType = ModuleTypeEnum::SPEC;
         } else if (args[idx] == "--impl" || args[idx] == "-impl") {
-            opts.moduleType = ModuleType::IMPL;
+            opts.moduleType = ModuleTypeEnum::IMPL;
         }
     }
-    if (opts.moduleType == ModuleType::UNKNOWN) {
+    if (opts.moduleType == ModuleTypeEnum::UNKNOWN) {
         log("[unroll]: please specify module type.\n");
         return false;
     }

--- a/infrastructure/base/write_mlir_command.cpp
+++ b/infrastructure/base/write_mlir_command.cpp
@@ -12,7 +12,7 @@ XUANSONG_NAMESPACE_HEADER_START
 
 struct WriteMLIROptions {
     std::string outputFilename {"-"};
-    ModuleType moduleType {ModuleType::UNKNOWN};
+    ModuleTypeEnum moduleType {ModuleTypeEnum::UNKNOWN};
 };
 
 struct WriteMLIRCommand : public Command {
@@ -65,18 +65,18 @@ bool WriteMLIRCommand::parseOptions(const std::vector<std::string>& args, WriteM
     for (size_t idx = 0; idx < args.size(); idx++) {
         auto arg = args[idx];
         if (arg == "--spec" || arg == "-spec") {
-            opts.moduleType = ModuleType::SPEC;
+            opts.moduleType = ModuleTypeEnum::SPEC;
         } else if (arg == "--impl" || arg == "-impl") {
-            opts.moduleType = ModuleType::IMPL;
+            opts.moduleType = ModuleTypeEnum::IMPL;
         } else if (arg == "--miter" || arg == "-miter") {
-            opts.moduleType = ModuleType::MITER;
+            opts.moduleType = ModuleTypeEnum::MITER;
         } else {
             opts.outputFilename = arg;
             Utils::PathUtil::expandTilde(opts.outputFilename);
         }
     }
 
-    if (opts.moduleType == ModuleType::UNKNOWN) {
+    if (opts.moduleType == ModuleTypeEnum::UNKNOWN) {
         log("[write_mlir]: please specify module type.\n");
         return false;
     }

--- a/infrastructure/circt-passes/HWTransforms/hw_aggregate_to_comb.cpp
+++ b/infrastructure/circt-passes/HWTransforms/hw_aggregate_to_comb.cpp
@@ -52,7 +52,7 @@ struct HWStructExtractOpConversion : OpConversionPattern<hw::StructExtractOp> {
 
     LogicalResult
     matchAndRewrite(hw::StructExtractOp op, OpAdaptor adaptor, ConversionPatternRewriter &rewriter) const override {
-        auto structType = cast<hw::StructType>(op.getInput().getType());
+        auto structType = hw::type_cast<hw::StructType>(op.getInput().getType());
         auto fieldName = op.getFieldName();
 
         uint64_t offset = 0;

--- a/infrastructure/managers/equivfusion_manager/equivfusionManager.cpp
+++ b/infrastructure/managers/equivfusion_manager/equivfusionManager.cpp
@@ -49,34 +49,34 @@ mlir::ModuleOp EquivFusionManager::getMergedModuleOp() const {
     return mergedModuleOp_ ? mergedModuleOp_.get() : nullptr;
 }
 
-void EquivFusionManager::setModuleOp(mlir::OwningOpRef<mlir::ModuleOp> &module, ModuleType moduleType) {
+void EquivFusionManager::setModuleOp(mlir::OwningOpRef<mlir::ModuleOp> &module, ModuleTypeEnum moduleType) {
     switch (moduleType) {
-        case ModuleType::UNKNOWN:
-            assert(0 && "Invalid module type: UNKNOWN");
-            break;
-        case ModuleType::SPEC:
+        case ModuleTypeEnum::SPEC:
             setSpecModuleOp(module);
             break;
-        case ModuleType::IMPL:
+        case ModuleTypeEnum::IMPL:
             setImplModuleOp(module);
             break;
-        case ModuleType::MITER:
+        case ModuleTypeEnum::MITER:
             setMergedModuleOp(module);
+            break;
+        case ModuleTypeEnum::UNKNOWN:
+            assert(0 && "Invalid module type: UNKNOWN");
             break;
     }
 }
 
-mlir::ModuleOp EquivFusionManager::getModuleOp(ModuleType moduleType) {
+mlir::ModuleOp EquivFusionManager::getModuleOp(ModuleTypeEnum moduleType) {
     switch (moduleType) {
-        case ModuleType::UNKNOWN:
-            assert(0 && "Invalid module type: UNKNOWN");
-            return nullptr;
-        case ModuleType::SPEC:
+        case ModuleTypeEnum::SPEC:
             return getSpecModuleOp();
-        case ModuleType::IMPL:
+        case ModuleTypeEnum::IMPL:
             return getImplModuleOp();
-        case ModuleType::MITER:
+        case ModuleTypeEnum::MITER:
             return getMergedModuleOp();
+        default:
+            assert(0 && "Invalid module type");
+            return nullptr;
     }
 }
 

--- a/infrastructure/managers/equivfusion_manager/equivfusionManager.h
+++ b/infrastructure/managers/equivfusion_manager/equivfusionManager.h
@@ -1,3 +1,6 @@
+#ifndef EQUIVFUSION_MANAGER_H
+#define EQUIVFUSION_MANAGER_H
+
 #include "infrastructure/utils/namespace_macro.h"
 #include "mlir/IR/OwningOpRef.h"
 #include "mlir/IR/MLIRContext.h"
@@ -6,7 +9,7 @@
 
 XUANSONG_NAMESPACE_HEADER_START
 
-enum class ModuleType {
+enum class ModuleTypeEnum {
     UNKNOWN,
     SPEC,
     IMPL,
@@ -46,8 +49,8 @@ public:
     mlir::ModuleOp getMergedModuleOp() const;
     mlir::MLIRContext* getGlobalContext();
 
-    void setModuleOp(mlir::OwningOpRef<mlir::ModuleOp> &module, ModuleType moduleType);
-    mlir::ModuleOp getModuleOp(ModuleType moduleType);
+    void setModuleOp(mlir::OwningOpRef<mlir::ModuleOp> &module, ModuleTypeEnum moduleType);
+    mlir::ModuleOp getModuleOp(ModuleTypeEnum moduleType);
 
     void addInputPorts(const std::vector<std::string>& ports);
     void addOutputPorts(const std::vector<std::string>& ports);
@@ -60,4 +63,4 @@ public:
 
 XUANSONG_NAMESPACE_HEADER_END
 
-
+#endif // EQUIVFUSION_MANAGER_H

--- a/libs/Tools/EquivMiter/equiv_miter.h
+++ b/libs/Tools/EquivMiter/equiv_miter.h
@@ -2,6 +2,7 @@
 #define EQUIVFUSION_EQUIV_MITER_H
 
 #include "infrastructure/utils/namespace_macro.h"
+#include "infrastructure/managers/equivfusion_manager/equivfusionManager.h"
 
 #include "mlir/IR/MLIRContext.h"
 #include "mlir/IR/BuiltinOps.h"
@@ -13,10 +14,6 @@
 
 XUANSONG_NAMESPACE_HEADER_START
 
-enum struct DesignTypeEnum {
-    SPEC,
-    IMPL,
-};
 
 struct EquivMiterToolOptions {
     bool printIR {false};
@@ -33,22 +30,22 @@ public:
 
 private:
     static bool parseOptions(const std::vector<std::string>& args, EquivMiterToolOptions& opts);
-    static bool mergeModules(mlir::ModuleOp dest, mlir::ModuleOp src, EquivMiterToolOptions& opts, DesignTypeEnum designType);
+    static bool mergeModules(mlir::ModuleOp dest, mlir::ModuleOp src, EquivMiterToolOptions& opts, ModuleTypeEnum moduleType);
 
 private:
     static void populatePreparePasses(mlir::PassManager& pm);
 
-    static llvm::LogicalResult miterToSMT(mlir::PassManager& pm, mlir::ModuleOp module, llvm::raw_ostream& os,
-                                          const circt::equivfusion::EquivFusionMiterOptions& miterOpts);
-    static llvm::LogicalResult miterToAIGER(mlir::PassManager& pm, mlir::ModuleOp module, llvm::raw_ostream& os,
-                                            const circt::equivfusion::EquivFusionMiterOptions& miterOpts);
-    static llvm::LogicalResult miterToBTOR2(mlir::PassManager& pm, mlir::ModuleOp module, llvm::raw_ostream& os,
-                                            const circt::equivfusion::EquivFusionMiterOptions& miterOpts);
+    static llvm::LogicalResult executeMiterToSMT(mlir::PassManager &pm, mlir::ModuleOp module, llvm::raw_ostream &os,
+                                                 const circt::equivfusion::EquivFusionMiterOptions &miterOpts);
+
+    static llvm::LogicalResult executeMiterToAIGER(mlir::PassManager &pm, mlir::ModuleOp module, llvm::raw_ostream &os,
+                                                   const circt::equivfusion::EquivFusionMiterOptions &miterOpts);
+
+    static llvm::LogicalResult executeMiterToBTOR2(mlir::PassManager &pm, mlir::ModuleOp module, llvm::raw_ostream &os,
+                                                   const circt::equivfusion::EquivFusionMiterOptions &miterOpts);
 
 public:
-    static void help(const std::string& name, const std::string& description);
-
-    static bool run(const std::vector<std::string>& args);
+    static bool executeMiter(const std::vector<std::string>& args);
 };
 
 XUANSONG_NAMESPACE_HEADER_END // namespace XuanSong

--- a/solving/solver-runner/solver_declare.cpp
+++ b/solving/solver-runner/solver_declare.cpp
@@ -1,22 +1,29 @@
-#include <iostream>
 #include "solving/solver-runner/solver_declare.h"
 
 namespace XuanSong {
 
-int Z3Solver::run(const std::string &command) {
+int Z3Solver::run(const std::string &inputFile, const std::string &options) {
+    std::string command = getName() + " " + inputFile + " " + options;
     return executeCommand(command);
 }
 
-int BitwuzlaSolver::run(const std::string &command) {
+int BitwuzlaSolver::run(const std::string &inputFile, const std::string &options) {
+    std::string command = getName() + " " + inputFile + " " + options;
     return executeCommand(command);
 }
 
-int BtorMCSolver::run(const std::string &command) {
-    std::string actual_command = command + " --kind";
-    return executeCommand(actual_command);
+int BtorMCSolver::run(const std::string &inputFile, const std::string &options) {
+    std::string command = getName() + " " + inputFile + " " + options + " --kind";
+    return executeCommand(command);
 }
 
-int KissatSolver::run(const std::string &command) {
+int KissatSolver::run(const std::string &inputFile, const std::string &options) {
+    std::string cnfFile = inputFile + ".cnf";
+    if (convertToCNF(inputFile, cnfFile) != 0) {
+        return -1;
+    }
+
+    std::string command = getName() + " " + cnfFile + " " + options;
     int status = executeCommand(command);
     if (status == -1) {
         return -1;

--- a/solving/solver-runner/solver_declare.h
+++ b/solving/solver-runner/solver_declare.h
@@ -14,12 +14,18 @@ namespace XuanSong {
 class Solver {
 public:
     virtual ~Solver() = default;
-    virtual int run(const std::string &command) = 0;
+    virtual int run(const std::string &inputFile, const std::string &options) = 0;
     virtual std::string getName() const = 0;
 
 protected:
     int executeCommand(const std::string &command) {
         return system(command.c_str());
+    }
+
+    /// Convert AIG to CNF
+    int convertToCNF(const std::string &aigFile, const std::string &cnfFile) {
+        std::string command = "aigtocnf " + aigFile + " " + cnfFile;
+        return executeCommand(command);
     }
 };
 
@@ -28,7 +34,7 @@ protected:
 class ClassName : public Solver { \
 public: \
     std::string getName() const override { return SolverName; } \
-    int run(const std::string &command) override; \
+    int run(const std::string &inputFile, const std::string &options) override; \
 };
 
 SOLVER_LIST

--- a/solving/solver-runner/solver_runner.cpp
+++ b/solving/solver-runner/solver_runner.cpp
@@ -17,11 +17,6 @@ void SolverRunner::initializeSolvers() {
     }
 }
 
-int SolverRunner::run(Solver* solver, const std::string &command) {
-    assert(solver);
-    return solver->run(command);
-}
-
 int SolverRunner::run(const std::string &solverName, const std::string &inputFile, const std::string& options) {
     initializeSolvers();
 
@@ -33,7 +28,7 @@ int SolverRunner::run(const std::string &solverName, const std::string &inputFil
     assert(solverName == solver->getName());
 
     std::string command = solverName + " " + options + " " + inputFile;
-    return run(solver, command);
+    return solver->run(inputFile, options);
 }
 
 } // namespace XuanSong

--- a/solving/solver-runner/solver_runner.h
+++ b/solving/solver-runner/solver_runner.h
@@ -18,7 +18,6 @@ private:
         return it != solvers.end() ? it->second.get() : nullptr;
     }
 
-    static int run(Solver* solver, const std::string &command);
 public:
     static int run(const std::string &solverName, const std::string &inputFile, const std::string& options);
 };

--- a/test/integration_tests/cases/array_rtl2rtl/array.sv
+++ b/test/integration_tests/cases/array_rtl2rtl/array.sv
@@ -1,8 +1,10 @@
 module top(
     input logic in_logic_1,
+    input idx,
     input in_array_1 [1:0],
     input in_array_2 [1:0],
     input in_array_3 [2:0],
+    input in_array_4 [1:0][1:0],
 
     output [1:0] out_array_0,
 
@@ -15,7 +17,10 @@ module top(
     output reg out_array_7 [1:0],
     output out_array_8 [1:0],
 
-    output logic out_logic_1
+    output logic out_logic_1,
+    output logic out_logic_2,
+    output logic out_logic_3,
+    output logic out_logic_4
 );
     assign out_array_1 = in_array_1;
 
@@ -29,21 +34,27 @@ module top(
     assign out_array_5[1] = in_logic_1;                                 //  %1
 
     assign out_logic_1 = in_array_1[1];                                 //  %4 = hw.array_get %in_array_1[%true] : !hw.array<2xi1>, i1
+    assign out_logic_2 = in_array_1[idx];                               //  %5 = hw.array_get %in_array_1[%idx] : !hw.array<2xi1>, i1
 
-    assign out_array_6 = in_array_3[1:0];                               //  %5 = hw.array_slice %in_array_3[%c0_i2] : (!hw.array<3xi1>) -> !hw.array<2xi1>
+    assign out_logic_3 = in_array_4[1][1];                              //  %6 = hw.array_get %in_array_4[%true] : !hw.array<2xarray<2xi1>>, i1
+                                                                        //  %7 = hw.array_get %6[%true] : !hw.array<2xi1>, i1
+    assign out_logic_4 = in_array_4[idx][idx];                          //  %8 = hw.array_get %in_array_4[%idx] : !hw.array<2xarray<2xi1>>, i1
+                                                                        //  %9 = hw.array_get %8[%idx] : !hw.array<2xi1>, i1
+
+    assign out_array_6 = in_array_3[1:0];                               //  %10 = hw.array_slice %in_array_3[%c0_i2] : (!hw.array<3xi1>) -> !hw.array<2xi1>
 
     always_comb begin
-        out_array_7[1] = in_logic_1;                                    //  %6 = hw.array_inject %6[%true], %in_logic_1 : !hw.array<2xi1>, i1
+        out_array_7[1] = in_logic_1;                                    //  %11 = hw.array_inject %11[%true], %in_logic_1 : !hw.array<2xi1>, i1
     end
 
-    assign out_array_8 = in_logic_1 ? in_array_1 : in_array_2;         //   %7 = comb.mux %in_logic_1, %in_array_1, %in_array_2 : !hw.array<2xi1>
+    assign out_array_8 = in_logic_1 ? in_array_1 : in_array_2;         //   %12 = comb.mux %in_logic_1, %in_array_1, %in_array_2 : !hw.array<2xi1>
 endmodule
 
 
 /*
 // circt-verilog array.sv -o array.mlir
 module {
-  hw.module @array_assign(in %in_logic_1 : i1, in %in_array_1 : !hw.array<2xi1>, in %in_array_2 : !hw.array<2xi1>, in %in_array_3 : !hw.array<3xi1>, out out_array_0 : i2, out out_array_1 : !hw.array<2xi1>, out out_array_2 : !hw.array<2xi1>, out out_array_3 : !hw.array<2xi1>, out out_array_4 : !hw.array<2xi1>, out out_array_5 : !hw.array<2xi1>, out out_array_6 : !hw.array<2xi1>, out out_array_7 : !hw.array<2xi1>, out out_array_8 : !hw.array<2xi1>, out out_logic_1 : i1) {
+  hw.module @top(in %in_logic_1 : i1, in %idx : i1, in %in_array_1 : !hw.array<2xi1>, in %in_array_2 : !hw.array<2xi1>, in %in_array_3 : !hw.array<3xi1>, in %in_array_4 : !hw.array<2xarray<2xi1>>, out out_array_0 : i2, out out_array_1 : !hw.array<2xi1>, out out_array_2 : !hw.array<2xi1>, out out_array_3 : !hw.array<2xi1>, out out_array_4 : !hw.array<2xi1>, out out_array_5 : !hw.array<2xi1>, out out_array_6 : !hw.array<2xi1>, out out_array_7 : !hw.array<2xi1>, out out_array_8 : !hw.array<2xi1>, out out_logic_1 : i1, out out_logic_2 : i1, out out_logic_3 : i1, out out_logic_4 : i1) {
     %c-2_i2 = hw.constant -2 : i2
     %0 = hw.aggregate_constant [true, false] : !hw.array<2xi1>
     %c0_i2 = hw.constant 0 : i2
@@ -52,11 +63,15 @@ module {
     %2 = comb.replicate %in_logic_1 : (i1) -> i2
     %3 = hw.bitcast %c-2_i2 : (i2) -> !hw.array<2xi1>
     %4 = hw.array_get %in_array_1[%true] : !hw.array<2xi1>, i1
-    %5 = hw.array_slice %in_array_3[%c0_i2] : (!hw.array<3xi1>) -> !hw.array<2xi1>
-    %6 = hw.array_inject %6[%true], %in_logic_1 : !hw.array<2xi1>, i1
-    %7 = comb.mux %in_logic_1, %in_array_1, %in_array_2 : !hw.array<2xi1>
-    hw.output %2, %in_array_1, %0, %1, %3, %1, %5, %6, %7, %4 : i2, !hw.array<2xi1>, !hw.array<2xi1>, !hw.array<2xi1>, !hw.array<2xi1>, !hw.array<2xi1>, !hw.array<2xi1>, !hw.array<2xi1>, !hw.array<2xi1>, i1
+    %5 = hw.array_get %in_array_1[%idx] : !hw.array<2xi1>, i1
+    %6 = hw.array_get %in_array_4[%true] : !hw.array<2xarray<2xi1>>, i1
+    %7 = hw.array_get %6[%true] : !hw.array<2xi1>, i1
+    %8 = hw.array_get %in_array_4[%idx] : !hw.array<2xarray<2xi1>>, i1
+    %9 = hw.array_get %8[%idx] : !hw.array<2xi1>, i1
+    %10 = hw.array_slice %in_array_3[%c0_i2] : (!hw.array<3xi1>) -> !hw.array<2xi1>
+    %11 = hw.array_inject %11[%true], %in_logic_1 : !hw.array<2xi1>, i1
+    %12 = comb.mux %in_logic_1, %in_array_1, %in_array_2 : !hw.array<2xi1>
+    hw.output %2, %in_array_1, %0, %1, %3, %1, %10, %11, %12, %4, %5, %7, %9 : i2, !hw.array<2xi1>, !hw.array<2xi1>, !hw.array<2xi1>, !hw.array<2xi1>, !hw.array<2xi1>, !hw.array<2xi1>, !hw.array<2xi1>, !hw.array<2xi1>, i1, i1, i1, i1
   }
 }
-
 */

--- a/test/integration_tests/cases/array_rtl2rtl/array_rtl2rtl.sh
+++ b/test/integration_tests/cases/array_rtl2rtl/array_rtl2rtl.sh
@@ -21,7 +21,6 @@ equiv_fusion -p "read_v -spec -top top array.sv" \
 #CHECK: UNSATISFIABLE
 equiv_fusion -p "read_v -spec -top top array.sv" \
              -p "read_v -impl -top top array.sv" \
-             -p "equiv_miter -specModule top -implModule top -mitermode aiger -o $OUTPUT_DIR/miter.aiger"
-aigtocnf "$OUTPUT_DIR/miter.aiger" "$OUTPUT_DIR/miter.cnf"
-equiv_fusion -p "solver_runner --solver kissat --inputfile $OUTPUT_DIR/miter.cnf"
+             -p "equiv_miter -specModule top -implModule top -mitermode aiger -o $OUTPUT_DIR/miter.aiger" \
+             -p "solver_runner --solver kissat --inputfile $OUTPUT_DIR/miter.aiger"
 

--- a/test/integration_tests/cases/dot64_run_kissat_with_aiger2/dot64_run_kissat_with_aiger2.sh
+++ b/test/integration_tests/cases/dot64_run_kissat_with_aiger2/dot64_run_kissat_with_aiger2.sh
@@ -5,12 +5,8 @@ set -euo pipefail
 CASE_DIR=$(dirname "$(realpath "$0")")
 OUTPUT_DIR=${CASE_LOG_PATH:-.}
 
+#CHECK: UNSATISFIABLE
 equiv_fusion -p "read_c -spec -top mm mm.mlir" \
              -p "read_v -impl -top dot64_comb dot64.v" \
              -p "equiv_miter -specModule mm -implModule dot64_comb -mitermode aiger -o $OUTPUT_DIR/miter.aiger" \
              -p "solver_runner --solver kissat --inputfile $OUTPUT_DIR/miter.aiger"
-
-aigtocnf $OUTPUT_DIR/miter.aiger $OUTPUT_DIR/miter.cnf
-
-#CHECK: UNSATISFIABLE
-equiv_fusion -p "solver_runner --solver kissat --inputfile $OUTPUT_DIR/miter.cnf"

--- a/test/integration_tests/cases/lzc_c_to_dichotomy_run_kissat/lzc_c_to_dichotomy_run_kissat.sh
+++ b/test/integration_tests/cases/lzc_c_to_dichotomy_run_kissat/lzc_c_to_dichotomy_run_kissat.sh
@@ -5,11 +5,8 @@ set -euo pipefail
 CASE_DIR=$(dirname "$(realpath "$0")")
 OUTPUT_DIR=${CASE_LOG_PATH:-.}
 
+#CHECK: UNSATISFIABLE
 equiv_fusion -p "read_c -spec -top LZC LZC.mlir" \
              -p "read_v -impl -top lzc7_dichotomy lzc_dichotomy.v" \
-             -p "equiv_miter -specModule LZC -implModule lzc7_dichotomy -mitermode aiger -o $OUTPUT_DIR/miter.aiger"
-
-aigtocnf "$OUTPUT_DIR/miter.aiger" "$OUTPUT_DIR/miter.cnf"
-
-#CHECK: UNSATISFIABLE
-equiv_fusion -p "solver_runner --solver kissat --inputfile $OUTPUT_DIR/miter.cnf"
+             -p "equiv_miter -specModule LZC -implModule lzc7_dichotomy -mitermode aiger -o $OUTPUT_DIR/miter.aiger" \
+             -p "solver_runner --solver kissat --inputfile $OUTPUT_DIR/miter.aiger"

--- a/test/integration_tests/cases/lzc_c_to_loop_run_kissat/lzc_c_to_loop_run_kissat.sh
+++ b/test/integration_tests/cases/lzc_c_to_loop_run_kissat/lzc_c_to_loop_run_kissat.sh
@@ -5,11 +5,8 @@ set -euo pipefail
 CASE_DIR=$(dirname "$(realpath "$0")")
 OUTPUT_DIR=${CASE_LOG_PATH:-.}
 
+#CHECK: UNSATISFIABLE
 equiv_fusion -p "read_c -spec -top LZC LZC.mlir" \
              -p "read_v -impl -top lzc7_loop lzc_loop.v" \
-             -p "equiv_miter -specModule LZC -implModule lzc7_loop -mitermode aiger -o $OUTPUT_DIR/miter.aiger"
-
-aigtocnf "$OUTPUT_DIR/miter.aiger" "$OUTPUT_DIR/miter.cnf"
-
-#CHECK: UNSATISFIABLE
-equiv_fusion -p "solver_runner --solver kissat --inputfile $OUTPUT_DIR/miter.cnf"
+             -p "equiv_miter -specModule LZC -implModule lzc7_loop -mitermode aiger -o $OUTPUT_DIR/miter.aiger" \
+             -p "solver_runner --solver kissat --inputfile $OUTPUT_DIR/miter.aiger"

--- a/test/integration_tests/cases/multiple_dimensional_test/multiple_dimensional_test.sh
+++ b/test/integration_tests/cases/multiple_dimensional_test/multiple_dimensional_test.sh
@@ -5,12 +5,9 @@ set -euo pipefail
 CASE_DIR=$(dirname "$(realpath "$0")")
 OUTPUT_DIR=${CASE_LOG_PATH:-.}
 
+#CHECK: UNSATISFIABLE
 equiv_fusion -p "read_c -spec -top test multiple_dimensional_test.mlir" \
              -p "read_c -impl -top test multiple_dimensional_test.mlir" \
-             -p "equiv_miter -specModule test -implModule test -mitermode aiger -o $OUTPUT_DIR/miter.aiger"
-
-aigtocnf "$OUTPUT_DIR/miter.aiger" "$OUTPUT_DIR/miter.cnf"
-
-#CHECK: UNSATISFIABLE
-equiv_fusion -p "solver_runner --solver kissat --inputfile $OUTPUT_DIR/miter.cnf"
+             -p "equiv_miter -specModule test -implModule test -mitermode aiger -o $OUTPUT_DIR/miter.aiger" \
+             -p "solver_runner --solver kissat --inputfile $OUTPUT_DIR/miter.aiger"
 

--- a/test/integration_tests/cases/struct_rtl2rtl/struct_rtl2rtl.sh
+++ b/test/integration_tests/cases/struct_rtl2rtl/struct_rtl2rtl.sh
@@ -21,7 +21,6 @@ equiv_fusion -p "read_v -spec -top top struct.sv" \
 #CHECK: UNSATISFIABLE
 equiv_fusion -p "read_v -spec -top top struct.sv" \
              -p "read_v -impl -top top struct.sv" \
-             -p "equiv_miter -specModule top -implModule top -mitermode aiger -o $OUTPUT_DIR/miter.aiger"
-aigtocnf "$OUTPUT_DIR/miter.aiger" "$OUTPUT_DIR/miter.cnf"
-equiv_fusion -p "solver_runner --solver kissat --inputfile $OUTPUT_DIR/miter.cnf"
+             -p "equiv_miter -specModule top -implModule top -mitermode aiger -o $OUTPUT_DIR/miter.aiger" \
+             -p "solver_runner --solver kissat --inputfile $OUTPUT_DIR/miter.aiger"
 


### PR DESCRIPTION
【需求编号】
US-019

【需求描述】
在case array_rtl2rtl中添加muti_array[idx][idx]

【一句话总结实现】
在array_rtl2rtl/array.sv中添加相关代码

【实现细节】
1. 在array_rtl2rtl/array.sv中添加相关代码
2. 重构："aigtocnf "封装成convertToCNF()，在KissatSolver::run()中调用
3. 重构：libs/Tools/EquivMiter/equiv_miter.cpp中EquivMiterTool::executeMiterToBTOR2()去除以下Pass的执行，HWToBTOR2已支持
 - createEquivFusionReplicateToConcat()
 - createEquivFusionDecomposeConcat()
 - createSimplifyVariadicOpsPass()
4. 重构：infrastructure/circt-passes/HWTransforms/hw_aggregate_ops_convert.cpp中HWArraySliceOpConversion::matchAndRewrite()去除特殊的hw::ArraySliceOp的处理，circt已正确处理成hw::ArrayGetOp
