### PR TITLE
[Frontend][US-022] Add Dockerfile for EquivFusion

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+circt_prebuild
+build
+solving/dep_solvers
+.vscode
+.metals
+.scala-build

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,46 @@
+FROM ubuntu:24.04
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update && apt-get install -y \
+    build-essential \
+    cmake \
+    ccache \
+    ninja-build \
+    git \
+    curl \
+    ca-certificates \
+    meson \
+    pkg-config \
+    libgmp-dev \
+    libmpfr-dev \
+    python3 \
+    python3-pip \
+    python3-venv \
+    python3-dev \
+    libreadline-dev \
+    libz3-dev \
+    z3 \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+COPY . /app/EquivFusion
+
+WORKDIR /app/EquivFusion
+
+RUN mkdir build && cd build \
+    && cmake .. -G Ninja -DCMAKE_BUILD_TYPE=Debug \
+    && ninja && ninja install_solvers
+
+RUN python3 -m venv torch_mlir_venv \
+    && torch_mlir_venv/bin/python -m pip install --upgrade pip \
+    && torch_mlir_venv/bin/pip install --pre torch-mlir torchvision \
+    --extra-index-url https://download.pytorch.org/whl/nightly/cpu \
+    -f https://github.com/llvm/torch-mlir-release/releases/expanded_assets/dev-wheels
+    
+ENV PATH="/app/EquivFusion/build/bin:/app/EquivFusion/circt_prebuild/bin:$PATH"
+
+CMD ["/bin/bash"]
+
+


### PR DESCRIPTION
【需求编号】
US-022

【需求描述】
为EquivFusion增加Dockerfile，方便不安装复杂依赖就能运行EquivFusion

【一句话总结实现】
添加Docker镜像文件Dockerfile

【实现细节】
Dockerfile中配置EquivFusion运行的linux系统版本，指定安装EquivFusion依赖的库，拷贝EquivFusion代码并进行编译。

【自测结果】
根据Dockerfile生成docker镜像，在容器中可以正常运行EquivFusion