### PR TITLE
[Frontend][US-023] Support automatic port mapping

### DIFF
--- a/infrastructure/circt-passes/FuncToHWModule/func_to_hw_module.cpp
+++ b/infrastructure/circt-passes/FuncToHWModule/func_to_hw_module.cpp
@@ -18,6 +18,7 @@
 #include "mlir/IR/Matchers.h"
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
 #include "mlir/IR/Types.h"
+#include "mlir/Analysis/TopologicalSortUtils.h"
 
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/DenseMap.h"
@@ -554,7 +555,9 @@ EquivFusionFuncToHWModulePass::copyOpFromFuncToHWModule(mlir::OpBuilder &builder
   }
 
   // Clone operations from func to hw.module. 
-  for (auto& op : llvm::make_early_inc_range(funcOp.getBody().front().getOperations())) {
+  mlir::Block &funcBody = funcOp.getBody().front();
+  mlir::sortTopologically(&funcBody);
+  for (auto& op : llvm::make_early_inc_range(funcBody.getOperations())) {
     if (auto returnOp = mlir::dyn_cast<mlir::func::ReturnOp>(op)) {
       // Create hw.output operation for the return values.
       for (mlir::Value returnValue : returnOp.getOperands()) {

--- a/test/integration_tests/cases/automatic_port_mapping/automatic_port_mapping.sh
+++ b/test/integration_tests/cases/automatic_port_mapping/automatic_port_mapping.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/bash
+
+set -euo pipefail
+
+CASE_DIR=$(dirname "$(realpath "$0")")
+OUTPUT_DIR=${CASE_LOG_PATH:-.}
+
+#CHECK: unsat
+equiv_fusion -p "read_v -spec -top top spec.v" \
+             -p "read_v -impl -top top impl.v" \
+             -p "equiv_miter -specModule top -implModule top -mitermode smtlib -o $OUTPUT_DIR/miter.smt" \
+             -p "solver_runner --solver z3 --inputfile $OUTPUT_DIR/miter.smt"
+
+#CHECK: unsat
+equiv_fusion -p "read_v -spec -top top spec.v" \
+             -p "read_v -impl -top top impl.v" \
+             -p "equiv_miter -specModule top -implModule top -mitermode btor2 -o $OUTPUT_DIR/miter.btor2" \
+             -p "solver_runner --solver bitwuzla --inputfile $OUTPUT_DIR/miter.btor2"
+
+
+#CHECK: UNSATISFIABLE
+equiv_fusion -p "read_v -spec -top top spec.v" \
+             -p "read_v -impl -top top impl.v" \
+             -p "equiv_miter -specModule top -implModule top -mitermode aiger -o $OUTPUT_DIR/miter.aiger" \
+             -p "solver_runner --solver kissat --inputfile $OUTPUT_DIR/miter.aiger"
+

--- a/test/integration_tests/cases/automatic_port_mapping/impl.v
+++ b/test/integration_tests/cases/automatic_port_mapping/impl.v
@@ -1,0 +1,16 @@
+module top (input [3:0] b,
+	    input [7:0] a,
+	    output reg [7:0] out,
+	    output [15:0] sum);
+    
+    assign sum = a + b;
+
+    always_comb begin
+	if (a > b) begin
+	    out = a + 1;
+	end else begin 
+	    out = b + 1;
+	end
+    end
+
+endmodule

--- a/test/integration_tests/cases/automatic_port_mapping/spec.v
+++ b/test/integration_tests/cases/automatic_port_mapping/spec.v
@@ -1,0 +1,16 @@
+module top (input [7:0] a,
+	    input [3:0] b,
+	    output [15:0] sum,
+	    output reg [7:0] out);
+    
+    assign sum = a + b;
+
+    always_comb begin
+	if (a > b) begin
+	    out = a + 1;
+	end else begin 
+	    out = b + 1;
+	end
+    end
+
+endmodule


### PR DESCRIPTION
【需求编号】
US-023

【需求描述】
在将spec module和impl module做miter时，支持两个module之间按端口名称进行自动匹配

【一句话总结实现】
实现spec module和impl module之间按照端口名称进行自动匹配

【实现细节】
1、检查spec module与impl module的端口类型是否匹配，即输入输出端口的数目是否一致、端口名称是否一致、相同名称端口的类型是否一致
2、smt flow：
          构建verif.lec时，按照名称进行端口匹配，并将impl module的端口进行重排序，使得端口顺序与spec module排序一致
     aiger/btor flow：
          按照名称进行端口匹配，匹配的input输入相同的信号，检查匹配到的output端口的输出