### PR TITLE
[Command][US-025] Support show command

### DIFF
--- a/infrastructure/base/command.cpp
+++ b/infrastructure/base/command.cpp
@@ -7,7 +7,6 @@
 //===----------------------------------------------------------------------===//
 
 #include "infrastructure/base/command.h"
-#include <iostream>
 
 
 XUANSONG_NAMESPACE_HEADER_START
@@ -30,6 +29,20 @@ std::string Command::getDescription() const {
 
 Command *Command::getNextCommand() const {
     return nextCommand_;
+}
+
+void Command::prevExecute() {
+    startTime_ = std::chrono::steady_clock::now();
+}
+
+void Command::postExecute() {
+    auto endTime = std::chrono::steady_clock::now();
+    executedCommandsInfo_.emplace_back(ExecutedCommandInfo(this, startTime_, endTime));
+}
+
+std::vector<ExecutedCommandInfo> Command::executedCommandsInfo_ = std::vector<ExecutedCommandInfo>();
+std::vector<ExecutedCommandInfo>& Command::getExecutedCommandsInfo() {
+    return executedCommandsInfo_;
 }
 
 

--- a/infrastructure/base/command.h
+++ b/infrastructure/base/command.h
@@ -8,17 +8,31 @@
 
 #pragma once
 
+#include <chrono>
 #include <string>
 #include <vector>
 #include "infrastructure/utils/namespace_macro.h"
 
 XUANSONG_NAMESPACE_HEADER_START
-    
+
+struct ExecutedCommandInfo {
+    struct Command *command;
+    double time;  // seconds
+
+    ExecutedCommandInfo(Command *cmd,
+                        const std::chrono::steady_clock::time_point &startTime,
+                        const std::chrono::steady_clock::time_point &endTime) : command(cmd) {
+        std::chrono::duration<double> duration_s(endTime - startTime);
+        time = duration_s.count();
+    }
+};
+
 struct Command {
 private: 
     std::string name_;
     std::string description_;
     Command *nextCommand_;
+    std::chrono::steady_clock::time_point startTime_;
 
 public:
     Command(const std::string &name, const std::string &description);
@@ -27,14 +41,20 @@ public:
     Command(const Command &) = delete;
     Command &operator=(const Command &) = delete;
 
-    virtual void preExecute( ) = 0;
     virtual void execute(const std::vector<std::string> &args) = 0;
-    virtual void postExecute( ) = 0;
     virtual void help() = 0;
-    
+
     std::string getName() const;
     std::string getDescription() const;
     Command *getNextCommand() const;
+
+    void prevExecute();
+    void postExecute();
+
+private:
+    static std::vector<ExecutedCommandInfo> executedCommandsInfo_;
+protected:
+    static std::vector<ExecutedCommandInfo>& getExecutedCommandsInfo();
 };
 
 extern Command *firstCommand;

--- a/infrastructure/base/commandManager.cpp
+++ b/infrastructure/base/commandManager.cpp
@@ -56,7 +56,9 @@ void CommandManager::executeCommand(const std::string &name, const std::vector<s
     }
 
     Command *cmd = getCommand(name);
+    cmd->prevExecute();
     cmd->execute(args);
+    cmd->postExecute();
 }
 
 XUANSONG_NAMESPACE_HEADER_END

--- a/infrastructure/base/equiv_miter_command.cpp
+++ b/infrastructure/base/equiv_miter_command.cpp
@@ -16,14 +16,8 @@ public:
     EquivMiterCommand() : Command("equiv_miter", "construct miter for logical equivalence check") {}
     ~EquivMiterCommand() = default;
 
-    void preExecute() override {
-    }
-
     void execute(const std::vector<std::string>& args) override {
         EquivMiterTool::execute(args);
-    }
-
-    void postExecute() override {
     }
 
     void help() override {

--- a/infrastructure/base/help_command.cpp
+++ b/infrastructure/base/help_command.cpp
@@ -20,10 +20,6 @@ public:
     HelpCmd(const HelpCmd &) = delete;
     HelpCmd &operator=(const HelpCmd &) = delete;
 
-    void preExecute() override {
-        
-    }
-
     void execute(const std::vector<std::string> &args) override {
         CommandManager *commandMgr = CommandManager::getInstance();
 
@@ -43,10 +39,6 @@ public:
                 log("Error: Command '%s' not found\n", commandName.c_str());
             }
         }
-    }
-
-    void postExecute() override {
-        
     }
 
     void help() override {

--- a/infrastructure/base/history_command.cpp
+++ b/infrastructure/base/history_command.cpp
@@ -22,21 +22,12 @@ public:
     HistoryCmd(const HistoryCmd &) = delete;
     HistoryCmd &operator=(const HistoryCmd &) = delete;
 
-    void preExecute() override {
-
-    }
-
     void execute(const std::vector<std::string> &args) override {
         for(HIST_ENTRY **list = history_list(); *list != NULL; list++) {
             log("%s\n", (*list)->line);
         }
 
         log("\n");
-    }
-
-    void postExecute() override {
-        
-
     }
 
     void help() override { 

--- a/infrastructure/base/read_c_command.cpp
+++ b/infrastructure/base/read_c_command.cpp
@@ -61,9 +61,6 @@ struct ReadCCommand : public Command {
     llvm::LogicalResult executeHLS(const ReadCCommandOptions& opts);
     llvm::LogicalResult executeCFlow(const ReadCCommandOptions& opts);
 
-    void preExecute() override {
-    }
-
     void execute(const std::vector<std::string>& args) override { 
         ReadCCommandOptions opts;
         if (!parseOptions(args, opts)) {
@@ -78,9 +75,6 @@ struct ReadCCommand : public Command {
 
         EquivFusionManager::getInstance()->clearPorts();
         return;
-    }
-
-    void postExecute() override {
     }
 
     void help() override {

--- a/infrastructure/base/read_firrtl_command.cpp
+++ b/infrastructure/base/read_firrtl_command.cpp
@@ -20,14 +20,8 @@ struct ReadFIRRTLCommand : public Command {
     ReadFIRRTLCommand(ReadFIRRTLCommand &&) = delete;
     ReadFIRRTLCommand &operator=(ReadFIRRTLCommand &&) = delete;
 
-    void preExecute() override {
-    }
-
     void execute(const std::vector<std::string>& args) override {
         ReadFIRRTLTool::execute(args);
-    }
-
-    void postExecute() override {
     }
 
     void help() override {

--- a/infrastructure/base/read_v_command.cpp
+++ b/infrastructure/base/read_v_command.cpp
@@ -102,9 +102,6 @@ struct ReadVCommand : public Command {
     bool parseOptions(const std::vector<std::string>& args, ReadVCommandOptions& opts);
     llvm::LogicalResult executeRTLFlow(const ReadVCommandOptions& opts);
 
-    void preExecute() override {
-    }
-
     void execute(const std::vector<std::string>& args) override {
         ReadVCommandOptions opts;
         if (!parseOptions(args, opts)) {
@@ -127,9 +124,6 @@ struct ReadVCommand : public Command {
 
 
         return;
-    }
-
-    void postExecute() override {
     }
 
     void help() override {

--- a/infrastructure/base/set_port_command.cpp
+++ b/infrastructure/base/set_port_command.cpp
@@ -35,10 +35,6 @@ public:
 
     bool parseOptions(const std::vector<std::string>& args, SetPortCommandOptions& opts);
 
-    void preExecute() override {
-
-    }
-
     void execute(const std::vector<std::string>& args) override {
         SetPortCommandOptions opts;
         if (!parseOptions(args, opts)) {
@@ -47,9 +43,6 @@ public:
 
         EquivFusionManager::getInstance()->addInputPorts(opts.inputPorts);
         EquivFusionManager::getInstance()->addOutputPorts(opts.outputPorts);
-    }
-
-    void postExecute() override {
     }
 
     void help() override {

--- a/infrastructure/base/show_command.cpp
+++ b/infrastructure/base/show_command.cpp
@@ -1,0 +1,55 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the EquivFusion Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "infrastructure/base/command.h"
+#include "infrastructure/utils/log-util/log_util.h"
+
+
+XUANSONG_NAMESPACE_HEADER_START
+
+struct ShowCommand : public Command {
+public:
+    ShowCommand() : Command("show", "show executed information") {}
+    ~ShowCommand() = default;
+
+    ShowCommand(const ShowCommand &) = delete;
+    ShowCommand &operator=(const ShowCommand &) = delete;
+
+    void execute(const std::vector<std::string> &args) override {
+        double totalTime = 0.0;
+        const auto& executedCommandsInfo = getExecutedCommandsInfo();
+        for (const auto &executedCommandInfo: executedCommandsInfo) {
+            totalTime += executedCommandInfo.time;
+        }
+
+        log("\n");
+        log("==================== Show executed commands information ====================\n");
+        log("%20s    %-20s     %s\n", "No", "Command", "Time (seconds)");
+
+        int idx = 1;
+        for (const auto &executedCommandInfo: executedCommandsInfo) {
+            double time = executedCommandInfo.time;
+            log("%20d    %-20s    %8.6f %5.1f%%\n",
+                idx++, executedCommandInfo.command->getName().c_str(), time, 100.0 * time / totalTime);
+        }
+
+        log("%20s    %-20s    %8.6f %5.1f%%\n", "Total", "", totalTime, 100.0 * totalTime / totalTime);
+        log("============================================================================\n");
+        log("\n");
+    }
+
+    void help() override {
+        log("\n");
+        log("   OVERVIEW: %s - %s\n", getName().c_str(), getDescription().c_str());
+        log("   USAGE:    %s \n", getName().c_str());
+        log("   OPTIONS:\n");
+        log("\n");
+    }
+} showCmd;
+
+XUANSONG_NAMESPACE_HEADER_END

--- a/infrastructure/base/solver_command.cpp
+++ b/infrastructure/base/solver_command.cpp
@@ -23,9 +23,6 @@ public:
     SolverCommand() : Command("solver_runner", "run solver") {}
     ~SolverCommand() = default;
 
-    void preExecute() override {
-    }
-
     void execute(const std::vector<std::string>& args) override {
         SolverCommandOptions opts;
         if (!parseOptions(args, opts)) {
@@ -33,9 +30,6 @@ public:
         }
 
         XuanSong::SolverRunner::run(opts.solver, opts.inputFile, opts.options);
-    }
-
-    void postExecute() override {
     }
 
     void help() override {

--- a/infrastructure/base/unroll_command.cpp
+++ b/infrastructure/base/unroll_command.cpp
@@ -31,9 +31,6 @@ struct UnrollCommand : public Command {
     UnrollCommand(UnrollCommand &&) = delete;
     UnrollCommand &operator=(UnrollCommand &&) = delete;
 
-    void preExecute() override {
-    }
-
     void execute(const std::vector<std::string> &args) override {
         UnrollOptions opts;
         if (!parseOptions(args, opts)) {
@@ -45,8 +42,6 @@ struct UnrollCommand : public Command {
         }
     }
 
-    void postExecute() override {
-    }
     void help() override {
         log("\n");
         log("   OVERVIEW: %s - %s\n", getName().c_str(), getDescription().c_str());

--- a/infrastructure/base/write_command.cpp
+++ b/infrastructure/base/write_command.cpp
@@ -20,14 +20,8 @@ public:
     WriteCommand(const std::string& name, const std::string& description) : Command(name, description) {}
     ~WriteCommand() = default;
 
-    void preExecute() override {
-    }
-
     void execute(const std::vector<std::string>& args) override {
         Impl::run(args);
-    }
-
-    void postExecute() override {
     }
 
     void help() override {

--- a/infrastructure/base/write_mlir_command.cpp
+++ b/infrastructure/base/write_mlir_command.cpp
@@ -31,9 +31,6 @@ public:
     WriteMLIRCommand(const WriteMLIRCommand &) = delete;
     WriteMLIRCommand &operator=(const WriteMLIRCommand &) = delete;
 
-    void preExecute() override {
-    }
-
     void execute(const std::vector<std::string>& args) override {
         WriteMLIROptions opts;
         if (!parseOptions(args, opts)) {
@@ -44,9 +41,6 @@ public:
             log("[write_mlir]: run failed\n\n");
             return;
         }
-    }
-
-    void postExecute() override {
     }
 
     void help() override {


### PR DESCRIPTION
【需求编号】
US-025

【需求描述】
支持show命令，输出已经执行过的command的运行时间

【一句话总结实现】
实现show command输出已经执行过的command的运行时间

【实现细节】
1. command.h中添加static成员executedCommandsInfo_，记录执行过的command和执行时间
2. Command::prevExecute()记录开始时间，Command::postExecute()计算运行时间，并在CommandManager::executeCommand()中调用
3. 添加show_command.cpp打印相关信息。